### PR TITLE
Fix TOML syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ensure that an OpenCL library is installed for your platform and that `clinfo`
 or some other diagnostic command will run. Add the following to your project's
 `Cargo.toml`:
 
-```rust
+```toml
 [dependencies]
 ocl = "0.15"
 ```


### PR DESCRIPTION
Before:
![before SS](https://user-images.githubusercontent.com/6709544/31056066-54e709ae-a6cc-11e7-98d5-dd7425f42931.png)

After:
![after SS](https://user-images.githubusercontent.com/6709544/31056071-62957c34-a6cc-11e7-9b95-6bd7ddb1d25c.png)


