### PR TITLE
Fixed compilation error with Mesa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ opencl_version_1_1 = ["ocl-core/opencl_version_1_1"]
 opencl_version_1_2 = ["ocl-core/opencl_version_1_2"]
 opencl_version_2_0 = ["ocl-core/opencl_version_2_0"]
 opencl_version_2_1 = ["ocl-core/opencl_version_2_1"]
+opencl_vendor_mesa = ["ocl-core/opencl_vendor_mesa"]
 
 # Enabling this feature causes all `Future::poll` functions to behave in a
 # thread-blocking manner, causing the calling thread to block then return

--- a/examples/images/Cargo.toml
+++ b/examples/images/Cargo.toml
@@ -3,6 +3,9 @@ name = "images"
 version = "0.1.0"
 authors = ["Nick Sanders <cogciprocate@gmail.com>"]
 
+[features]
+opencl_vendor_mesa = ["ocl/opencl_vendor_mesa"]
+
 [dependencies]
 colorify = "*"
 image = "*"

--- a/examples/images_safe_clamp/Cargo.toml
+++ b/examples/images_safe_clamp/Cargo.toml
@@ -3,6 +3,9 @@ name = "ocl-example-rgb2gray"
 version = "0.0.2"
 authors = ["Bernhard Schuster <bernhard@ahoi.io>", "Nick Sanders <cogciprocate@gmail.com>"]
 
+[features]
+opencl_vendor_mesa = ["ocl/opencl_vendor_mesa"]
+
 [dependencies]
 ocl = { path = "../../" }
 image = "*"

--- a/examples/runall.sh
+++ b/examples/runall.sh
@@ -1,25 +1,46 @@
 #!/bin/bash
-cargo run --example async_cycles "$@"
-cargo run --example async_menagerie "$@"
-cargo run --example async_process "$@"
-cargo run --example basics "$@"
-cargo run --example device_check "$@"
-cargo run --example event_callbacks "$@"
-cargo run --example img_formats "$@"
-cargo run --example info_core "$@"
-cargo run --example info "$@"
-# cargo run --example map_buffers "$@"
-cargo run --example threads "$@"
-cargo run --example timed "$@"
-cargo run --example trivial "$@"
+
+VENDOR=""
+while getopts v: option
+do
+ case "${option}"
+ in
+ v) VENDOR=$OPTARG;;
+ esac
+done
+
+# Construct feature list.
+FEATURES=""
+if [ "$VENDOR" = "mesa" ]; then
+    FEATURES=$FEATURES" opencl_vendor_mesa "
+fi
+
+# Any features enabled?
+if [ "$FEATURES" != "" ]; then
+    FEATURES="--features "$FEATURES
+fi
+
+cargo run --example async_cycles "$@" $FEATURES
+cargo run --example async_menagerie "$@" $FEATURES
+cargo run --example async_process "$@" $FEATURES
+cargo run --example basics "$@" $FEATURES
+cargo run --example device_check "$@" $FEATURES
+cargo run --example event_callbacks "$@" $FEATURES
+cargo run --example img_formats "$@" $FEATURES
+cargo run --example info_core "$@" $FEATURES
+cargo run --example info "$@" $FEATURES
+# cargo run --example map_buffers "$@" $FEATURES
+cargo run --example threads "$@" $FEATURES
+cargo run --example timed "$@" $FEATURES
+cargo run --example trivial "$@" $FEATURES
 
 cd examples
 cd images
 cargo update
-cargo run "$@"
+cargo run "$@" $FEATURES
 cd ..
 
 cd images_safe_clamp
 cargo update
-cargo run "$@"
+cargo run "$@" $FEATURES
 cd ../..

--- a/src/standard/buffer.rs
+++ b/src/standard/buffer.rs
@@ -7,13 +7,15 @@ use std::error::Error as StdError;
 // use std::sync::atomic::{AtomicBool, Ordering};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut, Range};
-use ffi::cl_GLuint;
 use core::{self, Error as OclError, ErrorKind as OclErrorKind, Result as OclResult, OclPrm, Mem as
     MemCore, MemFlags, MemInfo, MemInfoResult, BufferRegion, MapFlags, AsMem, MemCmdRw, MemCmdAll,
     ClNullEventPtr};
 use ::{Context, Queue, SpatialDims, FutureMemMap, MemMap, Event, RwVec, FutureReadGuard,
     FutureWriteGuard};
 use standard::{ClNullEventPtrEnum, ClWaitListPtrEnum};
+
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use ffi::cl_GLuint;
 
 
 fn check_len(mem_len: usize, data_len: usize, offset: usize) -> OclResult<()> {
@@ -564,6 +566,8 @@ impl<'c, T> BufferCmd<'c, T> where T: 'c + OclPrm {
                     },
                 }
             },
+
+            #[cfg(not(feature="opencl_vendor_mesa"))]
             BufferCmdKind::Fill { pattern, len } => {
                 match self.shape {
                     BufferCmdDataShape::Lin { offset } => {
@@ -582,7 +586,6 @@ impl<'c, T> BufferCmd<'c, T> where T: 'c + OclPrm {
                         Please use the default shape, linear.")
                 }
             },
-
             #[cfg(not(feature="opencl_vendor_mesa"))]
             BufferCmdKind::GLAcquire => {
                 // core::enqueue_acquire_gl_buffer(queue, &self.buffer.obj_core, self.ewait, self.enew)
@@ -1668,6 +1671,7 @@ impl<T: OclPrm> Buffer<T> {
     /// See the [`BufferCmd` docs](struct.BufferCmd.html)
     /// for more info.
     ///
+    #[cfg(not(feature="opencl_vendor_mesa"))]
     pub fn from_gl_buffer<'o, D, Q>(que_ctx: Q, flags_opt: Option<MemFlags>, /*dims: D,*/
             gl_object: cl_GLuint) -> OclResult<Buffer<T>>
             where D: Into<SpatialDims>, Q: Into<QueCtx<'o>>

--- a/src/standard/buffer.rs
+++ b/src/standard/buffer.rs
@@ -582,16 +582,21 @@ impl<'c, T> BufferCmd<'c, T> where T: 'c + OclPrm {
                         Please use the default shape, linear.")
                 }
             },
+
+            #[cfg(not(feature="opencl_vendor_mesa"))]
             BufferCmdKind::GLAcquire => {
                 // core::enqueue_acquire_gl_buffer(queue, &self.buffer.obj_core, self.ewait, self.enew)
                 let buf_slc = unsafe { std::slice::from_raw_parts(&self.buffer.obj_core, 1) };
                 core::enqueue_acquire_gl_objects(queue, buf_slc, self.ewait, self.enew)
             },
+
+            #[cfg(not(feature="opencl_vendor_mesa"))]
             BufferCmdKind::GLRelease => {
                 // core::enqueue_release_gl_buffer(queue, &self.buffer.obj_core, self.ewait, self.enew)
                 let buf_slc = unsafe { std::slice::from_raw_parts(&self.buffer.obj_core, 1) };
                 core::enqueue_release_gl_objects(queue, buf_slc, self.ewait, self.enew)
             },
+
             BufferCmdKind::Unspecified => OclError::err_string("ocl::BufferCmd::enq(): \
                 No operation specified. Use '.read(...)', 'write(...)', etc. before calling \
                 '.enq()'."),

--- a/src/standard/image.rs
+++ b/src/standard/image.rs
@@ -436,16 +436,21 @@ impl<'c, T: 'c + OclPrm> ImageCmd<'c, T> {
                 core::enqueue_copy_image(queue, self.obj_core, dst_image, self.origin,
                     dst_origin, self.region, self.ewait, self.enew)
             },
+
+            #[cfg(not(feature="opencl_vendor_mesa"))]
             ImageCmdKind::GLAcquire => {
                 // core::enqueue_acquire_gl_buffer(queue, self.obj_core, self.ewait, self.enew)
                 let buf_slc = unsafe { std::slice::from_raw_parts(self.obj_core, 1) };
                 core::enqueue_acquire_gl_objects(queue, buf_slc, self.ewait, self.enew)
             },
+
+            #[cfg(not(feature="opencl_vendor_mesa"))]
             ImageCmdKind::GLRelease => {
                 // core::enqueue_release_gl_buffer(queue, self.obj_core, self.ewait, self.enew)
                 let buf_slc = unsafe { std::slice::from_raw_parts(self.obj_core, 1) };
                 core::enqueue_release_gl_objects(queue, buf_slc, self.ewait, self.enew)
             },
+
             ImageCmdKind::Unspecified => OclError::err_string("ocl::ImageCmd::enq(): No operation \
                 specified. Use '.read(...)', 'write(...)', etc. before calling '.enq()'."),
             _ => unimplemented!(),

--- a/src/standard/image.rs
+++ b/src/standard/image.rs
@@ -11,15 +11,19 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::marker::PhantomData;
 // use std::convert::Into;
-use ffi::{cl_GLuint, cl_GLint};
 use core::error::{Error as OclError, Result as OclResult};
 use core::{self, OclPrm, Mem as MemCore, MemFlags, MemObjectType, ImageFormatParseResult,
     ImageFormat, ImageDescriptor, ImageInfo, ImageInfoResult, MemInfo, MemInfoResult,
-    ImageChannelOrder, ImageChannelDataType, GlTextureTarget, AsMem, MemCmdRw, MemCmdAll,
+    ImageChannelOrder, ImageChannelDataType, AsMem, MemCmdRw, MemCmdAll,
     MapFlags};
 use standard::{Context, Queue, SpatialDims, ClNullEventPtrEnum, ClWaitListPtrEnum,
     QueCtx};
 use ::MemMap;
+
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use ffi::{cl_GLuint, cl_GLint};
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use core::{GlTextureTarget};
 
 
 /// The type of operation to be performed by a command.
@@ -682,6 +686,7 @@ impl<T: OclPrm> Image<T> {
 
     /// Returns a new `Image` from an existant GL texture2D/3D.
     // [WORK IN PROGRESS]
+    #[cfg(not(feature="opencl_vendor_mesa"))]
     pub fn from_gl_texture<'o, Q>(que_ctx: Q, flags: MemFlags, image_desc: ImageDescriptor,
             texture_target: GlTextureTarget, miplevel: cl_GLint, texture: cl_GLuint)
             -> OclResult<Image<T>>
@@ -728,6 +733,7 @@ impl<T: OclPrm> Image<T> {
 
     /// Returns a new `Image` from an existant renderbuffer.
     // [WORK IN PROGRESS]
+    #[cfg(not(feature="opencl_vendor_mesa"))]
     pub fn from_gl_renderbuffer<'o, Q>(que_ctx: Q, flags: MemFlags, image_desc: ImageDescriptor,
             renderbuffer: cl_GLuint) -> OclResult<Image<T>>
             where Q: Into<QueCtx<'o>>


### PR DESCRIPTION
Excluded functions related to context sharing OpenGL. This fixes issue #83.

Currently Mesa does not support context sharing with OpenGL. The related functions are missing from the Mesa library and will cause linker errors if referenced.
    
Constants and structs related to the context sharing with OpenGL still included. Reasoning: Easier to develop libraries / applications that in some configurations require OpenGL context sharing. With the constants and structs included, there is potentially less functionality that the library / application needs to exclude with Mesa.

NOTE1: To test your setup with mesa, run "examples/runall.sh -v mesa".

NOTE2: This merge request depends on my similar merge request in projects cl-sys and ocl-core.

NOTE3: My own system isn't exactly stable at the moment with Mesa. Running the examples with the "runall.sh -v mesa" script spits out various errors and the "timed" test enters infinite loop with one CPU core running at 100% utilization. I'll try to see where the problems are.

Platform [0]: Clover
Device [0]: AMD Radeon RX 580 Series (AMD POLARIS10 / DRM 3.18.0 / 4.13.11-gentoo, LLVM 4.0.1)
    VALUE MISMATCH AT INDEX [0]: Float4([-224837550000000000000000000000000000000, -224837550000000000000000000000000000000, -224837550000000000000000000000000000000, -224837550000000000000000000000000000000]) != Float4([-150, -150, -150, -150])
    Out-of-order MW/Async-CB:       <failure>
    VALUE MISMATCH AT INDEX [0]: Float4([0, 0, 0, 0]) != Float4([-150, -150, -150, -150])
    Out-of-order MW/Async-CB+AHP:   <failure>
    VALUE MISMATCH AT INDEX [1835008]: Float4([-248847010000000000000000000000000000000, -248847010000000000000000000000000000000, -248847010000000000000000000000000000000, -248847010000000000000000000000000000000]) != Float4([-150, -150, -150, -150])
    Out-of-order MW/ASync+CB/MR:    <failure>
    In-order MW/ASync+CB:           <success>
    Out-of-order MW/ELOOP:          <success>
    Out-of-order MW/ELOOP+CB:       <success>

Platform[0]: Clover (Mesa)                                                                                                                                                                                                                                                     
DEVICES: [Device(DeviceId(0x7f9dc82849a8))]
Device[0]: Radeon RX 580 Series (AMD POLARIS10 / DRM 3.18.0 / 4.13.11-gentoo, LLVM 4.0.1) (AMD)                                                                                                                                                                                
Spawning threads... 
0:[D0.I0], 1:[D0.I1], 2:[D0.I2], 3:[D0.I3], 4:[D0.I4], 

Results: 
amdgpu: buffer list creation failed (-22)
./runall.sh: line 33:  2491 Segmentation fault      (core dumped) cargo run --example threads "$@" $FEATURES
       Fresh nodrop v0.1.12



[  325.848252] 3:[D0.I3][2089]: segfault at 7f8ca5be84b0 ip 00007f8cae7408f5 sp 00007f8ca83fb090 error 4 in pipe_radeonsi.so[7f8cae659000+1e8000]

