### PR TITLE
Fixed retrieval of several program binaries

### DIFF
--- a/ocl-core/src/functions.rs
+++ b/ocl-core/src/functions.rs
@@ -1879,6 +1879,7 @@ fn get_program_info_raw(program: &Program, request: ProgramInfo) -> OclCoreResul
 fn get_program_info_binaries(program: &Program) -> OclCoreResult<Vec<Vec<u8>>> {
     let binary_sizes_raw = get_program_info_raw(program, ProgramInfo::BinarySizes)?;
     let binary_sizes = unsafe { ::util::bytes_into_vec::<usize>(binary_sizes_raw)? };
+    let n_binaries = binary_sizes.len();
 
     let binaries = binary_sizes.into_iter().map(|size| {
         vec![0u8; size]
@@ -1891,7 +1892,7 @@ fn get_program_info_binaries(program: &Program) -> OclCoreResult<Vec<Vec<u8>>> {
     let errcode = unsafe { ffi::clGetProgramInfo(
         program.as_ptr() as cl_program,
         ProgramInfo::Binaries as cl_program_info,
-        mem::size_of::<usize>(),
+        mem::size_of::<*mut c_void>()*n_binaries,
         binary_ptrs.as_mut_ptr() as *mut _ as *mut c_void,
         0 as *mut size_t,
     ) };


### PR DESCRIPTION
When running on several devices, the get_program_binaries call failes with the CL_INVALID_VALUE error because of the wrong parameter size.