### PR TITLE
Update trivial_exploded to avoid errors.

### DIFF
--- a/ocl/examples/trivial.rs
+++ b/ocl/examples/trivial.rs
@@ -102,7 +102,7 @@ fn trivial_exploded() -> ocl::Result<()> {
     // (1) Define which platform and device(s) to use. Create a context,
     // queue, and program then define some dims (compare to step 1 above).
     let platform = Platform::default();
-    let device = Device::first(platform)?;
+    let device = Device::first(platform);
     let context = Context::builder()
         .platform(platform)
         .devices(device.clone())
@@ -123,7 +123,7 @@ fn trivial_exploded() -> ocl::Result<()> {
     let buffer = Buffer::<f32>::builder()
         .queue(queue.clone())
         .flags(flags::MEM_READ_WRITE | flags::MEM_COPY_HOST_PTR)
-        .len(dims)
+        .dims(dims)
         .host_data(&vec)
         .build()?;
 


### PR DESCRIPTION
Thanks for sharing this project.

I tried to run examples/trivial on my environment but some errors occurred.
```
error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> src/main.rs:105:18
    |
105 |     let device = Device::first(platform)?;
    |                  ------------------------
    |                  |
    |                  the `?` operator cannot be applied to type `ocl::Device`
    |                  in this macro invocation
    |
    = help: the trait `std::ops::Try` is not implemented for `ocl::Device`
    = note: required by `std::ops::Try::into_result`

error[E0599]: no method named `len` found for type `ocl::builders::BufferBuilder<'_, f32>` in the current scope
   --> src/main.rs:127:10
    |
127 |         .len(dims) // Changed
    |          ^^^

error: aborting due to 2 previous errors

error: Could not compile `rust_ocl_practice`.
```

My environment.

name | version
--|---
OS | Ubuntu17.10 64bit
CPU | Intel® Core™ i7-4600U CPU @ 2.10GHz × 4
GPU | Intel® Haswell Mobile
rust | 1.23.0

I'm not sure what is correct but I could run the program with changing code as this PR.
Is there any other way to avoid these error?

Thank you.