### PR TITLE
Use `DeviceType::DEFAULT` as default, as the name implies.

### DIFF
--- a/ocl-core/src/functions.rs
+++ b/ocl-core/src/functions.rs
@@ -3549,7 +3549,7 @@ pub fn default_device_type() -> OclCoreResult<DeviceType> {
             "ALL" => Ok(DeviceType::ALL),
             _ => Err(ApiWrapperError::DefaultDeviceTypeInvalidType(s.to_owned()).into()),
         },
-        Err(_) => Ok(DeviceType::ALL),
+        Err(_) => Ok(DeviceType::DEFAULT),
     }
 }
 


### PR DESCRIPTION
`DeviceType::DEFAULT` should be used as default, as is implied by its name. On macOS for example, it will use the CPU before the GPU when using `DeviceType::ALL`, whereas with `DeviceType::DEFAULT` it correctly uses the GPU by default.