### PR TITLE
Fix dependency on yanked futures version

### DIFF
--- a/ocl/ocl-extras/Cargo.toml
+++ b/ocl/ocl-extras/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2"
 rand = "0.4"
 failure = "0.1"
 
-[dependencies.futures]
+[dependencies.futures-preview]
 version = "~0.2.1"
 git = "https://github.com/rust-lang-nursery/futures-rs"
 # branch = "master"


### PR DESCRIPTION
The 0.2.x series of the futures crate was yanked and re-released as
futures-preview.