### PR TITLE
Do not call set_kernel_arg on None args

### DIFF
--- a/ocl/src/standard/kernel.rs
+++ b/ocl/src/standard/kernel.rs
@@ -1421,7 +1421,9 @@ impl<'b> KernelBuilder<'b> {
             }
 
             let val = arg.to_arg_val();
-            core::set_kernel_arg(&obj_core, arg_idx as u32, val)?;
+            if !val.is_null() {
+                core::set_kernel_arg(&obj_core, arg_idx as u32, val)?;
+            }
         }
 
         let arg_types = if all_arg_types_unknown || disable_arg_check {


### PR DESCRIPTION
Currently calling the `.arg_named()` function on KernelBuilder with a None parameter will cause it to fail to `.build()` with the error CL_INVALID_ARG_VALUE on clSetKernelArg, making it impossible to create a kernel unless all parameters are available during creation.

This stops it from trying to bind parameters which were passed as None.