### PR TITLE
Implement raw info functions for devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Cargo.lock
 /src/junk
 /bak
 
+# IntelliJ
+.idea/
+*.iml

--- a/ocl-core/src/lib.rs
+++ b/ocl-core/src/lib.rs
@@ -158,7 +158,7 @@ pub use self::functions::{get_platform_ids, get_platform_info, get_device_ids, g
     enqueue_barrier_with_wait_list, get_extension_function_address_for_platform, wait_for_event,
     event_status, default_platform_idx, program_build_err, verify_context, default_platform,
     default_device_type, device_versions, event_is_complete, _dummy_event_callback,
-    _complete_user_event, get_context_platform};
+    _complete_user_event, get_context_platform, get_device_info_raw};
 
 #[cfg(not(feature="opencl_vendor_mesa"))]
 pub use self::functions::{

--- a/ocl/src/standard/device.rs
+++ b/ocl/src/standard/device.rs
@@ -425,6 +425,12 @@ impl Device {
         }
     }
 
+    /// Returns raw info about the device, as a vector of bytes. Intended for use with non-standard
+    /// OpenCL extensions.
+    pub fn info_raw(&self, info_kind: u32) -> OclResult<Vec<u8>> {
+        core::get_device_info_raw(&self.0, info_kind).map_err(OclError::from)
+    }
+
     /// Returns info about the device.
     pub fn info(&self, info_kind: DeviceInfo) -> OclResult<DeviceInfoResult> {
         core::get_device_info(&self.0, info_kind).map_err(OclError::from)


### PR DESCRIPTION
This adds `get_device_info_raw` in `ocl-core` and `Device.info_raw` in `ocl`, which return a `Vec<u8>` rather than a `DeviceInfoResult`. This allows querying info provided by non-standard OpenCL extensions. I haven't implemented this for any other OpenCL objects (platforms, contexts, etc) because I'm not aware of any cases where it's needed, but if you want I can add that as well.