### PR TITLE
Fix disabling argument type check

### DIFF
--- a/ocl/src/standard/kernel.rs
+++ b/ocl/src/standard/kernel.rs
@@ -1424,7 +1424,7 @@ impl<'b> KernelBuilder<'b> {
 
         let mut arg_types = Vec::with_capacity(num_args as usize);
         let mut all_arg_types_unknown = true;
-        let mut disable_arg_check = false;
+        let mut disable_arg_check = self.disable_arg_check;
 
         // Cache argument types for later use, bypassing if the OpenCL version
         // is too low (v1.1).


### PR DESCRIPTION
The flag which is set in KernelBuilder::disable_arg_type_check() is
never used in build function
Fixes #131.