### PR TITLE
Export internal value of OpenclVersion

### DIFF
--- a/ocl-core/src/types/structs.rs
+++ b/ocl-core/src/types/structs.rs
@@ -161,6 +161,10 @@ impl OpenclVersion {
         OpenclVersion { ver: [u16::max_value(), u16::max_value()] }
     }
 
+    pub fn to_raw(&self) -> (u16, u16) {
+        (self.ver[0], self.ver[1])
+    }
+
     /// Parse the string `ver` and return a dual-integer result as
     /// `OpenclVersion`.
     ///


### PR DESCRIPTION
Currently there is no way to access raw value of device OpenCL version, which can be useful
on setup with devices with different versions. I did it via to_raw function, so internal representation
can change.