### PR TITLE
Derive Hash for Device and Platform objects

### DIFF
--- a/ocl/src/standard/device.rs
+++ b/ocl/src/standard/device.rs
@@ -247,7 +247,7 @@ impl From<DeviceType> for DeviceSpecifier {
 
 /// An individual device identifier (an OpenCL device_id).
 ///
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct Device(DeviceIdCore);
 

--- a/ocl/src/standard/platform.rs
+++ b/ocl/src/standard/platform.rs
@@ -40,7 +40,7 @@ impl Extensions {
 /// A platform identifier.
 ///
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Hash)]
 pub struct Platform(PlatformIdCore);
 
 impl Platform {


### PR DESCRIPTION
Right now, the `DeviceId` and `PlatformId` types derive `Hash`, but not `Device` or `Platform`, meaning they can't be stored in a `HashSet`. This PR changes that so that `Device` and `Platform` also derive `Hash`.

I haven't changed this for any of the other types, since their respective ocl-core types don't already derive `Hash` for some reason, but I can add that if you prefer.

Implements #136.