### PR TITLE
trait objects without an explicit `dyn` are deprecated

### DIFF
--- a/ocl-core/src/error.rs
+++ b/ocl-core/src/error.rs
@@ -77,7 +77,7 @@ impl Error {
 
     /// Returns the immediate cause of this error (e.g. the next error in the
     /// chain).
-    pub fn cause(&self) -> Option<&Fail> {
+    pub fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 }
@@ -95,7 +95,7 @@ impl fmt::Display for Error {
 }
 
 impl Fail for Error {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 

--- a/ocl-core/src/functions.rs
+++ b/ocl-core/src/functions.rs
@@ -2287,7 +2287,7 @@ pub fn get_kernel_work_group_info<D: ClDeviceIdPtr>(obj: &Kernel, device_obj: D,
 //============================================================================
 
 /// Blocks until the first `num_events` events in `event_list` are complete.
-pub fn wait_for_events(num_events: u32, event_list: &ClWaitListPtr) -> OclCoreResult<()> {
+pub fn wait_for_events(num_events: u32, event_list: &dyn ClWaitListPtr) -> OclCoreResult<()> {
     assert!(event_list.count() >= num_events);
 
     let errcode = unsafe {

--- a/ocl/src/error.rs
+++ b/ocl/src/error.rs
@@ -62,13 +62,13 @@ impl Error {
 
     /// Returns the immediate cause of this error (e.g. the next error in the
     /// chain).
-    pub fn cause(&self) -> Option<&Fail> {
+    pub fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 }
 
 impl Fail for Error {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 

--- a/ocl/src/standard/event.rs
+++ b/ocl/src/standard/event.rs
@@ -1109,8 +1109,8 @@ impl<'a> From<RawEventArray> for EventList {
     }
 }
 
-impl<'a> From<Box<ClWaitListPtr>> for EventList {
-    fn from(trait_obj: Box<ClWaitListPtr>) -> EventList {
+impl<'a> From<Box<dyn ClWaitListPtr>> for EventList {
+    fn from(trait_obj: Box<dyn ClWaitListPtr>) -> EventList {
         let raw_slice = unsafe {
             ::std::slice::from_raw_parts(trait_obj.as_ptr_ptr(), trait_obj.count() as usize)
         };
@@ -1119,8 +1119,8 @@ impl<'a> From<Box<ClWaitListPtr>> for EventList {
     }
 }
 
-impl<'a> From<&'a Box<ClWaitListPtr>> for EventList {
-    fn from(trait_obj: &Box<ClWaitListPtr>) -> EventList {
+impl<'a> From<&'a Box<dyn ClWaitListPtr>> for EventList {
+    fn from(trait_obj: &Box<dyn ClWaitListPtr>) -> EventList {
         let raw_slice = unsafe {
             ::std::slice::from_raw_parts(trait_obj.as_ptr_ptr(), trait_obj.count() as usize)
         };
@@ -1129,8 +1129,8 @@ impl<'a> From<&'a Box<ClWaitListPtr>> for EventList {
     }
 }
 
-impl<'a> From<Ref<'a, ClWaitListPtr>> for EventList {
-    fn from(trait_obj: Ref<'a, ClWaitListPtr>) -> EventList {
+impl<'a> From<Ref<'a, dyn ClWaitListPtr>> for EventList {
+    fn from(trait_obj: Ref<'a, dyn ClWaitListPtr>) -> EventList {
         let raw_slice = unsafe {
             ::std::slice::from_raw_parts(trait_obj.as_ptr_ptr(), trait_obj.count() as usize)
         };

--- a/ocl/src/standard/mod.rs
+++ b/ocl/src/standard/mod.rs
@@ -135,8 +135,8 @@ mod types {
         EventSlice(&'a [Event]),
         EventPtrSlice(&'a [cl_event]),
         RefEventList(Ref<'a, EventList>),
-        RefTraitObj(Ref<'a, ClWaitListPtr>),
-        BoxTraitObj(Box<ClWaitListPtr>),
+        RefTraitObj(Ref<'a, dyn ClWaitListPtr>),
+        BoxTraitObj(Box<dyn ClWaitListPtr>),
     }
 
     impl<'a> ClWaitListPtrEnum<'a> {
@@ -292,14 +292,14 @@ mod types {
         }
     }
 
-    impl<'a> From<Ref<'a, ClWaitListPtr>> for ClWaitListPtrEnum<'a> {
-        fn from(e: Ref<'a, ClWaitListPtr>) -> ClWaitListPtrEnum<'a> {
+    impl<'a> From<Ref<'a, dyn ClWaitListPtr>> for ClWaitListPtrEnum<'a> {
+        fn from(e: Ref<'a, dyn ClWaitListPtr>) -> ClWaitListPtrEnum<'a> {
             ClWaitListPtrEnum::RefTraitObj(e)
         }
     }
 
-    impl<'a> From<Box<ClWaitListPtr>> for ClWaitListPtrEnum<'a> {
-        fn from(e: Box<ClWaitListPtr>) -> ClWaitListPtrEnum<'a> {
+    impl<'a> From<Box<dyn ClWaitListPtr>> for ClWaitListPtrEnum<'a> {
+        fn from(e: Box<dyn ClWaitListPtr>) -> ClWaitListPtrEnum<'a> {
             ClWaitListPtrEnum::BoxTraitObj(e)
         }
     }


### PR DESCRIPTION
On 2019-06-02 nightly