### PR TITLE
Fix `ocl-interop` not working on macos

### DIFF
--- a/ocl-interop/Cargo.toml
+++ b/ocl-interop/Cargo.toml
@@ -29,5 +29,5 @@ glfw = "0.20"
 [target.'cfg(target_os = "macos")'.dependencies]
 cgl = "^0.2"
 
-[target.'cfg(not(target_os="macos"))'.build-dependencies]
+[build-dependencies]
 gl_generator = "^0.5"

--- a/ocl-interop/src/lib.rs
+++ b/ocl-interop/src/lib.rs
@@ -39,7 +39,7 @@ pub fn get_properties_list() -> ocl::builders::ContextProperties {
     unsafe {
         let gl_context = cgl::CGLGetCurrentContext();
         let share_group = cgl::CGLGetShareGroup(gl_context);
-        properties.cgl_sharegroup(share_group);
+        properties = properties.cgl_sharegroup(share_group);
     }
 
     #[cfg(target_os = "android")]


### PR DESCRIPTION
I was unable to run `ocl-interop` due to `gl_generator` missing from the `build-dependencies`.
Fixed it in the `Cargo.toml`.

Then another problem popped out due to borrowing.
Fixed it in the `src/lib.rs`.
But this change may be applied to other os-specific blocks.