### PR TITLE
Fix mutable borrow from immutable input(s)

### DIFF
--- a/ocl/src/async/buffer_sink.rs
+++ b/ocl/src/async/buffer_sink.rs
@@ -356,7 +356,7 @@ impl<T: OclPrm> BufferSink<T> {
     /// Do not use unless you are 100% certain that there will be no other
     /// reads or writes for the entire access duration (only possible if
     /// manually manipulating the lock status).
-    pub unsafe fn as_mut_slice(&self) -> &mut [T] {
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [T] {
         let ptr = (*self.lock.as_mut_ptr()).memory.as_mut_ptr();
         let default_len = (*self.lock.as_ptr()).default_len;
         ::std::slice::from_raw_parts_mut(ptr, default_len)

--- a/ocl/src/async/buffer_stream.rs
+++ b/ocl/src/async/buffer_stream.rs
@@ -368,7 +368,7 @@ impl<T: OclPrm> BufferStream<T> {
     /// Do not use unless you are 100% certain that there will be no other
     /// reads or writes for the entire access duration (only possible if
     /// manually manipulating the lock status).
-    pub unsafe fn as_mut_slice(&self) -> &mut [T] {
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [T] {
         let ptr = (*self.lock.as_mut_ptr()).memory.as_mut_ptr();
         let len = (*self.lock.as_ptr()).default_len;
         ::std::slice::from_raw_parts_mut(ptr, len)

--- a/ocl/src/async/rw_vec.rs
+++ b/ocl/src/async/rw_vec.rs
@@ -65,7 +65,7 @@ impl<T> RwVec<T> {
     /// Do not use unless you are 100% certain that there will be no other
     /// reads or writes for the entire access duration (only possible if
     /// manually manipulating the lock status).
-    pub unsafe fn as_mut_slice(&self) -> &mut [T] {
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [T] {
         let ptr = (*self.lock.as_mut_ptr()).as_mut_ptr();
         let len = (*self.lock.as_ptr()).len();
         ::std::slice::from_raw_parts_mut(ptr, len)


### PR DESCRIPTION
For further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mut_from_ref

Clippy errors:

```
error: mutable borrow from immutable input(s)
   --> ocl/src/async/buffer_sink.rs:359:42
    |
359 |     pub unsafe fn as_mut_slice(&self) -> &mut [T] {
    |        

note: immutable borrow here
   --> ocl/src/async/buffer_sink.rs:359:32
    |
359 |     pub unsafe fn as_mut_slice(&self) -> &mut [T] {
    |                                ^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mut_from_ref


error: mutable borrow from immutable input(s)
   --> ocl/src/async/buffer_stream.rs:371:42
    |
371 |     pub unsafe fn as_mut_slice(&self) -> &mut [T] {
    |                                          ^^^^^^^^
    |

error: mutable borrow from immutable input(s)
  --> ocl/src/async/rw_vec.rs:68:42
   |
68 |     pub unsafe fn as_mut_slice(&self) -> &mut [T] {
   |                                          ^^^^^^^^
   |
```