### PR TITLE
Replace mem::uninitialized with mem::MaybeUninit

### DIFF
--- a/ocl/src/standard/event.rs
+++ b/ocl/src/standard/event.rs
@@ -288,13 +288,17 @@ impl Future for Event {
 
 /// Returns an empty, initialized (zeroed) event array.
 fn empty_event_array() -> NoDrop<[Event; 8]> {
-    let mut array: [Event; 8];
-    unsafe {
-        array = mem::uninitialized();
+    let array = {
+        let mut array: [mem::MaybeUninit<Event>; 8] = unsafe {
+            mem::MaybeUninit::uninit().assume_init()
+        };
+
         for elem in &mut array[..] {
-            ptr::write(elem, Event::empty());
+            *elem = mem::MaybeUninit::new(Event::empty());
         }
-    }
+
+        unsafe {mem::transmute::<_, [Event; 8]>(array)}
+    };
     NoDrop::new(array)
 }
 


### PR DESCRIPTION
Recently, `mem::uninitialized`, which has always been very UB-prone to use, has been replaced with `mem::MaybeUninit`. This PR replaces every use of the former by the latter, though it isn't a drop-in replacement (and as we're talking UB here we need to double-check).