### PR TITLE
Fix fill_event in the BufferBuilder

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,10 @@ Version 0. ()
 
 * Update to Rust 2018 Edition.
 
+Bug Fixes
+---------
+
+* Fix a buffer fill event assertion to allow for the usage of those events when using the BufferBuilder.
 
 Version 0.19.3 (2019-06-19)
 ===========================

--- a/ocl/src/standard/buffer.rs
+++ b/ocl/src/standard/buffer.rs
@@ -2323,7 +2323,7 @@ impl<'a, T> BufferBuilder<'a, T> where T: 'a + OclPrm {
     pub fn fill_event<'b, 'e, En>(mut self, enew: En) -> BufferBuilder<'a, T>
             where 'e: 'a, En: Into<ClNullEventPtrEnum<'e>> {
         match self.fill_val {
-            Some(ref fv) => assert!(fv.1.is_some(), "Buffer::fill_event: Fill event already set."),
+            Some(ref fv) => assert!(fv.1.is_none(), "Buffer::fill_event: Fill event already set."),
             None => panic!("Buffer::fill_event: Fill value must be set first"),
         }
         self.fill_val = self.fill_val.take().map(|fv| (fv.0, Some(enew.into())));


### PR DESCRIPTION
Fix a buffer fill event assertion to allow for the usage of those events when using the BufferBuilder.

The fix should allow for the fill event to be set/retrieved. Error before the fix:
```
thread 'tests::buffer_fill::fill_with_event' panicked at 'Buffer::fill_event: Fill event already set.', ocl/src/standard/buffer.rs:2326:29
```

This assertion will now only trigger when calling the fill_event method twice (or more).