### PR TITLE
Platform::list() return OclResult instead of panicking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ sudo: false
 addons:
   apt:
     sources:
-      - sourceline: 'ppa:intel-opencl/intel-opencl'
+      - sourceline: 'ppa:ocl-dev/intel-opencl'
     packages:
       - intel-opencl
       - ocl-icd-opencl-dev

--- a/ocl-core/Cargo.toml
+++ b/ocl-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ocl-core"
+name = "fil-ocl-core"
 version = "0.11.2"
 authors = ["Nick Sanders <cogciprocate@gmail.com>"]
 description = "A low-level OpenCL API."

--- a/ocl-core/Cargo.toml
+++ b/ocl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fil-ocl-core"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Nick Sanders <cogciprocate@gmail.com>"]
 description = "A low-level OpenCL API."
 documentation = "https://docs.rs/ocl-core/"

--- a/ocl-core/examples/info_core.rs
+++ b/ocl-core/examples/info_core.rs
@@ -2,7 +2,7 @@
 //!
 //! Set `INFO_FORMAT_MULTILINE` to `false` for compact printing.
 
-extern crate ocl_core as core;
+extern crate fil_ocl_core as core;
 
 use std::ffi::CString;
 use crate::core::error::Result as OclCoreResult;

--- a/ocl-core/examples/trivial.rs
+++ b/ocl-core/examples/trivial.rs
@@ -2,7 +2,7 @@
 //!
 //! Copied from ocl.
 
-extern crate ocl_core as core;
+extern crate fil_ocl_core as core;
 
 use std::ffi::CString;
 use crate::core::{ArgVal, ContextProperties, Event};
@@ -53,4 +53,3 @@ fn main() {
     // Print an element:
     println!("The value at index [{}] is now '{}'!", 200007, vec[200007]);
 }
-

--- a/ocl-core/examples/version.rs
+++ b/ocl-core/examples/version.rs
@@ -4,7 +4,7 @@
 //!
 //! [TODO (easy)]: Print all the devices on all the platforms.
 
-extern crate ocl_core as core;
+extern crate fil_ocl_core as core;
 
 use std::ffi::CString;
 

--- a/ocl-core/src/tests/depricated/test_timed.rs
+++ b/ocl-core/src/tests/depricated/test_timed.rs
@@ -4,7 +4,7 @@
 // running tests, increase `DATASET_SIZE`, and the `*_ITERS` consts.
 // The other consts can be anything at all
 
-// extern crate ocl;
+// extern crate fil_ocl as ocl;
 use std::time::Instant;
 
 use util;

--- a/ocl-interop/Cargo.toml
+++ b/ocl-interop/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["concurrency", "hardware-support", "api-bindings", "external-ffi-b
 license = "MIT/Apache-2.0"
 
 [dependencies]
-ocl = { path = "../ocl", version = "0.19" }
+fil-ocl = { path = "../ocl", version = "0.19" }
 
 # For tests
 [dev-dependencies]

--- a/ocl-interop/src/lib.rs
+++ b/ocl-interop/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "macos")]
 extern crate cgl;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 
 #[cfg(target_os = "linux")]
 #[allow(improper_ctypes)]

--- a/ocl-interop/src/lib.rs
+++ b/ocl-interop/src/lib.rs
@@ -52,7 +52,7 @@ pub fn get_properties_list() -> ocl::builders::ContextProperties {
 }
 
 pub fn get_context() -> std::option::Option<ocl::Context> {
-    ocl::Platform::list()
+    ocl::Platform::list().unwrap()
         .iter()
         .map(|plat| {
             //println!("Plat: {}",plat);

--- a/ocl-interop/tests/lib.rs
+++ b/ocl-interop/tests/lib.rs
@@ -1,6 +1,6 @@
 extern crate gl;
 extern crate glutin;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 extern crate ocl_interop;
 extern crate glfw;
 extern crate sdl2;

--- a/ocl/Cargo.toml
+++ b/ocl/Cargo.toml
@@ -4,7 +4,7 @@ name = "fil-ocl"
 # [REMINDER]: Bump `html_root_url` in `src/lib.rs`.
 # [REMINDER]: Bump version in `README.md`.
 # [REMINDER]: Set version and date in `RELEASES.md`.
-version = "0.19.3"
+version = "0.19.4"
 
 authors = ["Nick Sanders <cogciprocate@gmail.com>"]
 description = "OpenCL bindings and interfaces for Rust."
@@ -62,7 +62,7 @@ failure = "0.1"
 num-traits = "0.2"
 futures = "0.1"
 qutex = "0.2"
-fil-ocl-core = { version = "~0.11.2", path = "../ocl-core" }
+fil-ocl-core = { version = "~0.11.3", path = "../ocl-core" }
 
 [dev-dependencies]
 find_folder = "0.3"

--- a/ocl/Cargo.toml
+++ b/ocl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ocl"
+name = "fil-ocl"
 
 # [REMINDER]: Bump `html_root_url` in `src/lib.rs`.
 # [REMINDER]: Bump version in `README.md`.
@@ -25,11 +25,11 @@ travis-ci = { repository = "cogciprocate/ocl" }
 event_debug_print = []
 kernel_debug_print = []
 kernel_debug_sleep = []
-opencl_version_1_1 = ["ocl-core/opencl_version_1_1"]
-opencl_version_1_2 = ["ocl-core/opencl_version_1_2"]
-opencl_version_2_0 = ["ocl-core/opencl_version_2_0"]
-opencl_version_2_1 = ["ocl-core/opencl_version_2_1"]
-opencl_vendor_mesa = ["ocl-core/opencl_vendor_mesa"]
+opencl_version_1_1 = ["fil-ocl-core/opencl_version_1_1"]
+opencl_version_1_2 = ["fil-ocl-core/opencl_version_1_2"]
+opencl_version_2_0 = ["fil-ocl-core/opencl_version_2_0"]
+opencl_version_2_1 = ["fil-ocl-core/opencl_version_2_1"]
+opencl_vendor_mesa = ["fil-ocl-core/opencl_vendor_mesa"]
 
 # Enabling `future_guard_drop_panic` will cause `FutureGuard::drop` to panic
 # if the guard is dropped before polled. This is helpful when troubleshooting
@@ -62,7 +62,7 @@ failure = "0.1"
 num-traits = "0.2"
 futures = "0.1"
 qutex = "0.2"
-ocl-core = { version = "~0.11.2", path = "../ocl-core" }
+fil-ocl-core = { version = "~0.11.2", path = "../ocl-core" }
 
 [dev-dependencies]
 find_folder = "0.3"

--- a/ocl/examples/async_cycles.rs
+++ b/ocl/examples/async_cycles.rs
@@ -25,7 +25,7 @@
 extern crate chrono;
 extern crate futures;
 extern crate futures_cpupool;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use std::fmt::Debug;

--- a/ocl/examples/async_menagerie.rs
+++ b/ocl/examples/async_menagerie.rs
@@ -11,7 +11,7 @@ extern crate futures;
 extern crate futures_cpupool;
 extern crate rand;
 extern crate chrono;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 extern crate ocl_extras as extras;
 #[macro_use] extern crate colorify;
 

--- a/ocl/examples/async_process.rs
+++ b/ocl/examples/async_process.rs
@@ -7,7 +7,7 @@
 extern crate futures;
 extern crate futures_cpupool;
 extern crate chrono;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use std::cell::Cell;

--- a/ocl/examples/basics.rs
+++ b/ocl/examples/basics.rs
@@ -1,4 +1,4 @@
-extern crate ocl;
+extern crate fil_ocl as ocl;
 extern crate ocl_extras;
 
 use ocl::{ProQue, Buffer, MemFlags};

--- a/ocl/examples/device_check.rs
+++ b/ocl/examples/device_check.rs
@@ -17,7 +17,7 @@
 
 extern crate futures;
 extern crate rand;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate colorify;
 

--- a/ocl/examples/event_callbacks.rs
+++ b/ocl/examples/event_callbacks.rs
@@ -6,7 +6,7 @@
 //! example will likely fail on that platform.
 //!
 
-extern crate ocl;
+extern crate fil_ocl as ocl;
 extern crate ocl_extras;
 extern crate find_folder;
 

--- a/ocl/examples/images/Cargo.toml
+++ b/ocl/examples/images/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.2.0"
 authors = ["Nick Sanders <cogciprocate@gmail.com>"]
 
 [features]
-opencl_vendor_mesa = ["ocl/opencl_vendor_mesa"]
+opencl_vendor_mesa = ["fil-ocl/opencl_vendor_mesa"]
 
 [dependencies]
 colorify = "*"
 image = "*"
-ocl = { path = "../../" }
+fil-ocl = { path = "../../" }
 # ocl = { git = "https://github.com/cogciprocate/ocl" }
 # ocl-core = "0.3"
 # ocl-core = { git = "https://github.com/cogciprocate/ocl-core" }

--- a/ocl/examples/images/src/main.rs
+++ b/ocl/examples/images/src/main.rs
@@ -6,7 +6,7 @@
 //!
 
 extern crate image;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use std::path::Path;

--- a/ocl/examples/images_safe_clamp/Cargo.toml
+++ b/ocl/examples/images_safe_clamp/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.2.0"
 authors = ["Bernhard Schuster <bernhard@ahoi.io>", "Nick Sanders <cogciprocate@gmail.com>"]
 
 [features]
-opencl_vendor_mesa = ["ocl/opencl_vendor_mesa"]
+opencl_vendor_mesa = ["fil-ocl/opencl_vendor_mesa"]
 
 [dependencies]
-ocl = { path = "../../" }
+fil-ocl = { path = "../../" }
 image = "*"
 time = "*"
 find_folder = "*"

--- a/ocl/examples/images_safe_clamp/src/main.rs
+++ b/ocl/examples/images_safe_clamp/src/main.rs
@@ -35,7 +35,7 @@
 extern crate find_folder;
 extern crate image;
 extern crate time;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use std::path::Path;

--- a/ocl/examples/img_formats.rs
+++ b/ocl/examples/img_formats.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate colorify;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 use ocl::{Result as OclResult, Platform, Device, Context, Image};
 use ocl::enums::MemObjectType;
 

--- a/ocl/examples/info.rs
+++ b/ocl/examples/info.rs
@@ -9,7 +9,7 @@
 //!
 //!
 
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use ocl::{Result as OclResult, Platform, Device, Context, Queue, Buffer, Image, Sampler, Program,

--- a/ocl/examples/info_core.rs
+++ b/ocl/examples/info_core.rs
@@ -2,7 +2,7 @@
 //!
 //! Set `INFO_FORMAT_MULTILINE` to `false` for compact printing.
 
-extern crate ocl;
+extern crate fil_ocl as ocl;
 
 use ocl::core::{self, PlatformInfo, DeviceInfo, ContextInfo,
     CommandQueueInfo, MemInfo, ImageInfo, SamplerInfo, ProgramInfo,

--- a/ocl/examples/opencl_2_1/Cargo.toml
+++ b/ocl/examples/opencl_2_1/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nick Sanders <cogciprocate@gmail.com>"]
 
 [features]
-opencl_version_2_1 = ["ocl/opencl_version_2_1"]
+opencl_version_2_1 = ["fil-ocl/opencl_version_2_1"]
 default = ["opencl_version_2_1"]
 
 [dependencies]
@@ -12,7 +12,7 @@ colorify = "*"
 
 # cl-sys = { git = "https://github.com/cogciprocate/cl-sys", features = ["opencl_version_2_1"] }
 # ocl-core = { path = "../../../ocl-core", features = ["opencl_version_2_1"] }
-ocl = { path = "../../" }
+fil-ocl = { path = "../../" }
 
 # cl-sys = { git = "https://github.com/cogciprocate/cl-sys" }
 # ocl-core = { git = "https://github.com/cogciprocate/ocl-core" }

--- a/ocl/examples/opencl_2_1/src/main.rs
+++ b/ocl/examples/opencl_2_1/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports, unused_variables)]
 
-extern crate ocl;
+extern crate fil_ocl as ocl;
 
 use ocl::{flags, Platform, Device, Context, Queue, Program, Buffer, Kernel};
 

--- a/ocl/examples/opencl_2_1/src/main.rs
+++ b/ocl/examples/opencl_2_1/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), ocl::Error> {
     println!("Choosing platorm...");
 
     #[cfg(feature = "opencl_version_2_1")]
-    let platform = Platform::list().into_iter().find(|plat| plat.name().unwrap() == PLATFORM_NAME)
+    let platform = Platform::list().unwrap().into_iter().find(|plat| plat.name().unwrap() == PLATFORM_NAME)
         .unwrap_or(Platform::default());
 
     #[cfg(not(feature = "opencl_version_2_1"))]
@@ -97,5 +97,3 @@ fn main() -> Result<(), ocl::Error> {
     // println!("The value at index [{}] is now '{}'!", 200007, vec[200007]);
     Ok(())
 }
-
-

--- a/ocl/examples/proto/Cargo.toml
+++ b/ocl/examples/proto/Cargo.toml
@@ -12,7 +12,7 @@ description = "Protype examples."
 exclude = ["target/*", "*.png", "bak/*"]
 # categories = ["asynchronous", "concurrency", "science"]
 
-[dependencies.ocl]
+[dependencies.fil-ocl]
 # version = "0.12"
 path = "../.."
 # default-features = true

--- a/ocl/examples/proto/src/async_basics.rs
+++ b/ocl/examples/proto/src/async_basics.rs
@@ -7,7 +7,7 @@
 extern crate futures;
 extern crate futures_cpupool;
 extern crate chrono;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use std::cell::Cell;
@@ -187,10 +187,3 @@ pub fn main() {
         correct_val_count.get() / redundancy_count, fmt_duration(create_duration),
         fmt_duration(run_duration), fmt_duration(total_duration));
 }
-
-
-
-
-
-
-

--- a/ocl/examples/proto/src/async_cycles_2stage.rs
+++ b/ocl/examples/proto/src/async_cycles_2stage.rs
@@ -35,7 +35,7 @@
 extern crate chrono;
 extern crate futures;
 extern crate futures_cpupool;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use std::thread;

--- a/ocl/examples/threads.rs
+++ b/ocl/examples/threads.rs
@@ -12,7 +12,7 @@
 //! * TODO: Print the reference counts of each element at various points.
 
 extern crate rand;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 #[macro_use] extern crate colorify;
 
 use std::thread::{self, JoinHandle};

--- a/ocl/examples/timed.rs
+++ b/ocl/examples/timed.rs
@@ -9,7 +9,7 @@
 //! example may fail on that platform.
 
 extern crate time;
-extern crate ocl;
+extern crate fil_ocl as ocl;
 extern crate ocl_extras;
 // * TODO: Bring this back once `Instant` stabilizes: use
 //   std::time::Instant;

--- a/ocl/examples/trivial.rs
+++ b/ocl/examples/trivial.rs
@@ -1,4 +1,4 @@
-extern crate ocl;
+extern crate fil_ocl as ocl;
 use ocl::ProQue;
 
 fn trivial() -> ocl::Result<()> {

--- a/ocl/ocl-extras/Cargo.toml
+++ b/ocl/ocl-extras/Cargo.toml
@@ -11,7 +11,7 @@ Types used in examples and tests within the ocl library but that may be useful
 for others to use within their own projects.
 """
 
-[dependencies.ocl]
+[dependencies.fil-ocl]
 path = ".."
 # git = "https://github.com/cogciprocate/ocl"
 version = "0.19"
@@ -30,6 +30,3 @@ version = "0.2.2"
 # branch = "master"
 # path = "../futures-rs/futures"
 # version = "0.3.0-alpha.1"
-
-
-

--- a/ocl/ocl-extras/src/lib.rs
+++ b/ocl/ocl-extras/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate ocl;
+extern crate fil_ocl as ocl;
 extern crate rand;
 extern crate num_traits;
 extern crate futures;

--- a/ocl/src/lib.rs
+++ b/ocl/src/lib.rs
@@ -52,7 +52,7 @@ extern crate num_traits;
 extern crate futures;
 #[macro_use]
 extern crate failure;
-pub extern crate ocl_core as core;
+pub extern crate fil_ocl_core as core;
 
 
 #[cfg(test)]

--- a/ocl/src/standard/platform.rs
+++ b/ocl/src/standard/platform.rs
@@ -45,11 +45,10 @@ pub struct Platform(PlatformIdCore);
 
 impl Platform {
     /// Returns a list of all platforms avaliable on the host machine.
-    pub fn list() -> Vec<Platform> {
-        let list_core = core::get_platform_ids()
-            .expect("Platform::list: Error retrieving platform list");
+    pub fn list() -> OclResult<Vec<Platform>> {
+        let list_core = core::get_platform_ids()?;
 
-        list_core.into_iter().map(Platform::new).collect()
+        Ok(list_core.into_iter().map(Platform::new).collect())
     }
 
     /// Returns the first available platform.

--- a/ocl/src/tests/buffer_fill.rs
+++ b/ocl/src/tests/buffer_fill.rs
@@ -1,4 +1,4 @@
-// extern crate ocl;
+// extern crate fil_ocl as ocl;
 use crate::standard::ProQue;
 
 const DATASET_SIZE: usize = 1 << 20;

--- a/ocl/src/tests/buffer_sink_stream_cycles.rs
+++ b/ocl/src/tests/buffer_sink_stream_cycles.rs
@@ -25,7 +25,7 @@
 extern crate chrono;
 extern crate futures;
 extern crate futures_cpupool;
-// extern crate ocl;
+// extern crate fil_ocl as ocl;
 // #[macro_use] extern crate colorify;
 
 use std::fmt::Debug;


### PR DESCRIPTION
It is really unfortunate in the current api, as this will create a panic if no compatible gpu can be found. This fixes that issue.