### PR TITLE
Platform::list() return OclResult instead of panicking

### DIFF
--- a/ocl-interop/src/lib.rs
+++ b/ocl-interop/src/lib.rs
@@ -52,7 +52,7 @@ pub fn get_properties_list() -> ocl::builders::ContextProperties {
 }
 
 pub fn get_context() -> std::option::Option<ocl::Context> {
-    ocl::Platform::list()
+    ocl::Platform::list().unwrap()
         .iter()
         .map(|plat| {
             //println!("Plat: {}",plat);

--- a/ocl/examples/opencl_2_1/src/main.rs
+++ b/ocl/examples/opencl_2_1/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), ocl::Error> {
     println!("Choosing platorm...");
 
     #[cfg(feature = "opencl_version_2_1")]
-    let platform = Platform::list().into_iter().find(|plat| plat.name().unwrap() == PLATFORM_NAME)
+    let platform = Platform::list().unwrap().into_iter().find(|plat| plat.name().unwrap() == PLATFORM_NAME)
         .unwrap_or(Platform::default());
 
     #[cfg(not(feature = "opencl_version_2_1"))]
@@ -97,5 +97,3 @@ fn main() -> Result<(), ocl::Error> {
     // println!("The value at index [{}] is now '{}'!", 200007, vec[200007]);
     Ok(())
 }
-
-

--- a/ocl/src/standard/platform.rs
+++ b/ocl/src/standard/platform.rs
@@ -45,11 +45,10 @@ pub struct Platform(PlatformIdCore);
 
 impl Platform {
     /// Returns a list of all platforms avaliable on the host machine.
-    pub fn list() -> Vec<Platform> {
-        let list_core = core::get_platform_ids()
-            .expect("Platform::list: Error retrieving platform list");
+    pub fn list() -> OclResult<Vec<Platform>> {
+        let list_core = core::get_platform_ids()?;
 
-        list_core.into_iter().map(Platform::new).collect()
+        Ok(list_core.into_iter().map(Platform::new).collect())
     }
 
     /// Returns the first available platform.


### PR DESCRIPTION
It is really unfortunate in the current api, as this will create a panic if no compatible gpu can be found. This fixes that issue.