### PR TITLE
Fix images_safe_clamp example compilation

### DIFF
--- a/ocl/examples/images_safe_clamp/Cargo.toml
+++ b/ocl/examples/images_safe_clamp/Cargo.toml
@@ -9,7 +9,7 @@ opencl_vendor_mesa = ["ocl/opencl_vendor_mesa"]
 [dependencies]
 ocl = { path = "../../" }
 image = "*"
-time = "*"
+time = "0.2"
 find_folder = "*"
 colorify = "*"
 

--- a/ocl/examples/images_safe_clamp/src/main.rs
+++ b/ocl/examples/images_safe_clamp/src/main.rs
@@ -44,11 +44,10 @@ use ocl::enums::{ImageChannelOrder, ImageChannelDataType, MemObjectType};
 use find_folder::Search;
 
 
-fn print_elapsed(title: &str, start: time::Timespec) {
-    let time_elapsed = time::get_time() - start;
-    let elapsed_ms = time_elapsed.num_milliseconds();
+fn print_elapsed(title: &str, start: time::Instant) {
+    let elapsed = start.elapsed();
     let separator = if title.len() > 0 { ": " } else { "" };
-    println!("    {}{}{}.{:03}", title, separator, time_elapsed.num_seconds(), elapsed_ms);
+    println!("    {}{}{}.{:03}", title, separator, elapsed.whole_seconds(), elapsed.subsec_milliseconds());
 }
 
 
@@ -117,7 +116,7 @@ fn main() {
 
     printlnc!(royal_blue: "\nRunning kernel (unrolled)...");
     printlnc!(white_bold: "image dims: {:?}", &dims);
-    let start_time = time::get_time();
+    let start_time = time::Instant::now();
 
     unsafe { kernel.enq().unwrap(); }
     print_elapsed("kernel enqueued", start_time);
@@ -211,7 +210,7 @@ fn main() {
         gws_patch_count.0 * patch_size, gws_patch_count.1 * patch_size);
     printlnc!(white_bold: "edges dims: {:?}", edge_sizes);
 
-    let start_time = time::get_time();
+    let start_time = time::Instant::now();
 
     unsafe {
         kernel_bulk.enq().unwrap();


### PR DESCRIPTION
The images_safe_clamp example specifies '*' as the version for the time
crate.  Update the example to the v0.2 API and pin the version there.