### PR TITLE
Change Spatial Dims From<isize> to be consistent with other types. Impl FromPrimitive for SpatialDims.

### DIFF
--- a/ocl/src/standard/spatial_dims.rs
+++ b/ocl/src/standard/spatial_dims.rs
@@ -2,7 +2,7 @@
 use std::convert::From;
 use std::fmt::Debug;
 use std::ops::Index;
-use num_traits::{Num, ToPrimitive};
+use num_traits::{Num, ToPrimitive, FromPrimitive};
 use crate::error::{Result as OclResult};
 use crate::standard::{MemLen, WorkDims};
 use crate::core::util;
@@ -205,9 +205,10 @@ impl From<usize> for SpatialDims {
 // [FIXME]: Quit being lazy and implement FromPrimitive.
 impl From<isize> for SpatialDims {
     fn from(val: isize) -> SpatialDims {
-        assert!(val > 0, "Invalid 'SpatialDims' value: {}. \
+        /*assert!(val > 0, "Invalid 'SpatialDims' value: {}. \
             Dimensions must be greater than zero.", val);
-        (val as usize).into()
+        (val as usize).into()*/
+        to_usize(val).into()
     }
 }
 
@@ -221,7 +222,19 @@ impl From<u32> for SpatialDims {
 // [FIXME]: Quit being lazy and implement FromPrimitive.
 impl From<i32> for SpatialDims {
     fn from(val: i32) -> SpatialDims {
-        (val as isize).into()
+        //(val as isize).into()
+        to_usize(val).into()
+    }
+}
+
+impl FromPrimitive for SpatialDims {
+    fn from_i64(n: i64) -> Option<Self> {
+        n.to_usize()
+            .map(|n| n.into())
+    }
+    fn from_u64(n: u64) -> Option<Self> {
+        n.to_usize()
+            .map(|n| n.into())
     }
 }
 

--- a/ocl/src/standard/spatial_dims.rs
+++ b/ocl/src/standard/spatial_dims.rs
@@ -195,34 +195,26 @@ impl<'a> From<&'a SpatialDims> for SpatialDims {
     }
 }
 
-// [FIXME]: Quit being lazy and implement FromPrimitive.
 impl From<usize> for SpatialDims {
     fn from(val: usize) -> SpatialDims {
         SpatialDims::One(val)
     }
 }
 
-// [FIXME]: Quit being lazy and implement FromPrimitive.
 impl From<isize> for SpatialDims {
     fn from(val: isize) -> SpatialDims {
-        /*assert!(val > 0, "Invalid 'SpatialDims' value: {}. \
-            Dimensions must be greater than zero.", val);
-        (val as usize).into()*/
         to_usize(val).into()
     }
 }
 
-// [FIXME]: Quit being lazy and implement FromPrimitive.
 impl From<u32> for SpatialDims {
     fn from(val: u32) -> SpatialDims {
         (val as usize).into()
     }
 }
 
-// [FIXME]: Quit being lazy and implement FromPrimitive.
 impl From<i32> for SpatialDims {
     fn from(val: i32) -> SpatialDims {
-        //(val as isize).into()
         to_usize(val).into()
     }
 }


### PR DESCRIPTION
Currently SpatialDims::from(n: isize) would assert n > 0. This would disallow a 0 sized offset, and was only for isize, not for any other type. I changed this to call to_usize on signed types and a cast to usize for unsigned types. Also implemented FromPrimitive by mapping the ToPrimitive::to_usize implementation. I checked that the issue on my end was fixed by either forcing 0 as usize or the changes here. 

To reproduce:
```
use ocl::SpatialDims;
SpatialDims::from(0 as i32); // fine 
SpatialDims::from(0 as usize); // fine
SpatialDims::from(0 as isize); // panics
```