### PR TITLE
Fix compilation failure

### DIFF
--- a/ocl/examples/images_safe_clamp/Cargo.toml
+++ b/ocl/examples/images_safe_clamp/Cargo.toml
@@ -9,7 +9,7 @@ opencl_vendor_mesa = ["ocl/opencl_vendor_mesa"]
 [dependencies]
 ocl = { path = "../../" }
 image = "*"
-time = "*"
+time = "0.1"
 find_folder = "*"
 colorify = "*"
 


### PR DESCRIPTION
The time crate has advanced their version and changed inside since this was originally written, leading to compilation failure with error messages like:
"error[E0412]: cannot find type `Timespec` in crate `time`" and
"error[E0425]: cannot find function `get_time` in crate `time`".

This change pins the same minor version as the parent repo, thereby fixing the above mentioned issue.