### PR TITLE
DirectX D3D11 interop

### DIFF
--- a/cl-sys/src/cl_d3d11_h.rs
+++ b/cl-sys/src/cl_d3d11_h.rs
@@ -1,132 +1,102 @@
 //! OpenCL / DirectX 11 sharing.
 
-pub use crate::cl_h::cl_uint;
+// + NVIDIA extension https://registry.khronos.org/OpenCL/extensions/nv/cl_nv_d3d11_sharing.txt
 
-pub const CL_CONTEXT_D3D11_DEVICE_KHR: cl_uint = 0x401D;
+#![allow(
+    non_camel_case_types,
+    dead_code,
+    unused_variables,
+    improper_ctypes,
+    non_upper_case_globals
+)]
 
-// /**********************************************************************************
-//  * Copyright (c) 2008-2015 The Khronos Group Inc.
-//  *
-//  * Permission is hereby granted, free of charge, to any person obtaining a
-//  * copy of this software and/or associated documentation files (the
-//  * "Materials"), to deal in the Materials without restriction, including
-//  * without limitation the rights to use, copy, modify, merge, publish,
-//  * distribute, sublicense, and/or sell copies of the Materials, and to
-//  * permit persons to whom the Materials are furnished to do so, subject to
-//  * the following conditions:
-//  *
-//  * The above copyright notice and this permission notice shall be included
-//  * in all copies or substantial portions of the Materials.
-//  *
-//  * MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
-//  * KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
-//  * SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
-//  *    https://www.khronos.org/registry/
-//  *
-//  * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-//  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-//  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-//  * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-//  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//  * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-//  **********************************************************************************/
-// /* $Revision: 11708 $ on $Date: 2010-06-13 23:36:24 -0700 (Sun, 13 Jun 2010) $ */
-// #ifndef __OPENCL_CL_D3D11_H
-// #define __OPENCL_CL_D3D11_H
+use crate::cl_h::{
+    cl_command_queue, cl_command_type, cl_context, cl_context_info, cl_device_id, cl_event,
+    cl_image_info, cl_int, cl_mem, cl_mem_flags, cl_mem_info, cl_platform_id, cl_uint,
+};
+use libc::c_void;
 
-// #include <d3d11.h>
-// #include <CL/cl.h>
-// #include <CL/cl_platform.h>
+pub type cl_d3d11_device_source = cl_uint;
+pub type cl_d3d11_device_set = cl_uint;
+pub type cl_id3d11_buffer = *mut c_void;
+pub type cl_id3d11_texture2d = *mut c_void;
+pub type cl_id3d11_texture3d = *mut c_void;
 
-// #ifdef __cplusplus
-// extern "C" {
-// #endif
+// Error Codes
+pub const CL_INVALID_D3D11_DEVICE: cl_int = -1006;
+pub const CL_INVALID_D3D11_RESOURCE: cl_int = -1007;
+pub const CL_D3D11_RESOURCE_ALREADY_ACQUIRED: cl_int = -1008;
+pub const CL_D3D11_RESOURCE_NOT_ACQUIRED: cl_int = -1009;
 
-// /******************************************************************************
-//  * cl_khr_d3d11_sharing                                                       */
-// #define cl_khr_d3d11_sharing 1
+// cl_d3d11_device_source
+pub const CL_D3D11_DEVICE: cl_d3d11_device_source = 0x4019;
+pub const CL_D3D11_DXGI_ADAPTER: cl_d3d11_device_source = 0x401A;
 
-// typedef cl_uint cl_d3d11_device_source_khr;
-// typedef cl_uint cl_d3d11_device_set_khr;
+// cl_d3d11_device_set
+pub const CL_PREFERRED_DEVICES_FOR_D3D11: cl_d3d11_device_set = 0x401B;
+pub const CL_ALL_DEVICES_FOR_D3D11: cl_d3d11_device_set = 0x401C;
 
-// /******************************************************************************/
-// /* Error Codes */
-// #define CL_INVALID_D3D11_DEVICE_KHR                  -1006
-// #define CL_INVALID_D3D11_RESOURCE_KHR                -1007
-// #define CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR       -1008
-// #define CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR           -1009
+// cl_context_info
+pub const CL_CONTEXT_D3D11_DEVICE_KHR: cl_context_info = 0x401D;
+pub const CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES: cl_context_info = 0x402D;
 
-// /* cl_d3d11_device_source */
-// #define CL_D3D11_DEVICE_KHR                          0x4019
-// #define CL_D3D11_DXGI_ADAPTER_KHR                    0x401A
+// cl_mem_info
+pub const CL_MEM_D3D11_RESOURCE: cl_mem_info = 0x401E;
 
-// /* cl_d3d11_device_set */
-// #define CL_PREFERRED_DEVICES_FOR_D3D11_KHR           0x401B
-// #define CL_ALL_DEVICES_FOR_D3D11_KHR                 0x401C
+// cl_image_info
+pub const CL_IMAGE_D3D11_SUBRESOURCE: cl_image_info = 0x401F;
 
-// /* cl_context_info */
-// #define CL_CONTEXT_D3D11_DEVICE_KHR                  0x401D
-// #define CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES_KHR 0x402D
+// cl_command_type
+pub const CL_COMMAND_ACQUIRE_D3D11_OBJECTS: cl_command_type = 0x4020;
+pub const CL_COMMAND_RELEASE_D3D11_OBJECTS: cl_command_type = 0x4021;
 
-// /* cl_mem_info */
-// #define CL_MEM_D3D11_RESOURCE_KHR                    0x401E
+pub type clGetDeviceIDsFromD3D11_fn = extern "system" fn(
+    platform: cl_platform_id,
+    d3d_device_source: cl_d3d11_device_source,
+    d3d_object: *mut c_void,
+    d3d_device_set: cl_d3d11_device_set,
+    num_entries: cl_uint,
+    devices: *mut cl_device_id,
+    num_devices: *mut cl_uint,
+) -> cl_int;
 
-// /* cl_image_info */
-// #define CL_IMAGE_D3D11_SUBRESOURCE_KHR               0x401F
+pub type clCreateFromD3D11Buffer_fn = extern "system" fn(
+    context: cl_context,
+    flags: cl_mem_flags,
+    resource: cl_id3d11_buffer,
+    errcode_ret: *mut cl_int,
+) -> cl_mem;
 
-// /* cl_command_type */
-// #define CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR         0x4020
-// #define CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR         0x4021
+pub type clCreateFromD3D11Texture2D_fn = extern "system" fn(
+    context: cl_context,
+    flags: cl_mem_flags,
+    resource: cl_id3d11_texture2d,
+    subresource: cl_uint,
+    errcode_ret: *mut cl_int,
+) -> cl_mem;
 
-// /******************************************************************************/
-// typedef CL_API_ENTRY cl_int (CL_API_CALL *clGetDeviceIDsFromD3D11KHR_fn)(
-//     cl_platform_id             platform,
-//     cl_d3d11_device_source_khr d3d_device_source,
-//     void *                     d3d_object,
-//     cl_d3d11_device_set_khr    d3d_device_set,
-//     cl_uint                    num_entries,
-//     cl_device_id *             devices,
-//     cl_uint *                  num_devices) CL_API_SUFFIX__VERSION_1_2;
+pub type clCreateFromD3D11Texture3D_fn = extern "system" fn(
+    context: cl_context,
+    flags: cl_mem_flags,
+    resource: cl_id3d11_texture3d,
+    subresource: cl_uint,
+    errcode_ret: *mut cl_int,
+) -> cl_mem;
 
-// typedef CL_API_ENTRY cl_mem (CL_API_CALL *clCreateFromD3D11BufferKHR_fn)(
-//     cl_context     context,
-//     cl_mem_flags   flags,
-//     ID3D11Buffer * resource,
-//     cl_int *       errcode_ret) CL_API_SUFFIX__VERSION_1_2;
+pub type clEnqueueAcquireD3D11Objects_fn = extern "system" fn(
+    command_queue: cl_command_queue,
+    num_objects: cl_uint,
+    mem_objects: *const cl_mem,
+    num_events_in_wait_list: cl_uint,
+    event_wait_list: *const cl_event,
+    event: *mut cl_event,
+) -> cl_int;
 
-// typedef CL_API_ENTRY cl_mem (CL_API_CALL *clCreateFromD3D11Texture2DKHR_fn)(
-//     cl_context        context,
-//     cl_mem_flags      flags,
-//     ID3D11Texture2D * resource,
-//     UINT              subresource,
-//     cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-// typedef CL_API_ENTRY cl_mem (CL_API_CALL *clCreateFromD3D11Texture3DKHR_fn)(
-//     cl_context        context,
-//     cl_mem_flags      flags,
-//     ID3D11Texture3D * resource,
-//     UINT              subresource,
-//     cl_int *          errcode_ret) CL_API_SUFFIX__VERSION_1_2;
-
-// typedef CL_API_ENTRY cl_int (CL_API_CALL *clEnqueueAcquireD3D11ObjectsKHR_fn)(
-//     cl_command_queue command_queue,
-//     cl_uint          num_objects,
-//     const cl_mem *   mem_objects,
-//     cl_uint          num_events_in_wait_list,
-//     const cl_event * event_wait_list,
-//     cl_event *       event) CL_API_SUFFIX__VERSION_1_2;
-
-// typedef CL_API_ENTRY cl_int (CL_API_CALL *clEnqueueReleaseD3D11ObjectsKHR_fn)(
-//     cl_command_queue command_queue,
-//     cl_uint          num_objects,
-//     const cl_mem *   mem_objects,
-//     cl_uint          num_events_in_wait_list,
-//     const cl_event * event_wait_list,
-//     cl_event *       event) CL_API_SUFFIX__VERSION_1_2;
-
-// #ifdef __cplusplus
-// }
-// #endif
-
-// #endif  /* __OPENCL_CL_D3D11_H */
+pub type clEnqueueReleaseD3D11Objects_fn = extern "system" fn(
+    command_queue: cl_command_queue,
+    num_objects: cl_uint,
+    mem_objects: *const cl_mem,
+    num_events_in_wait_list: cl_uint,
+    event_wait_list: *const cl_event,
+    event: *mut cl_event,
+) -> cl_int;

--- a/cl-sys/src/cl_gl_h.rs
+++ b/cl-sys/src/cl_gl_h.rs
@@ -55,13 +55,7 @@ pub const CL_GLX_DISPLAY_KHR: cl_context_properties = 0x200A;
 pub const CL_WGL_HDC_KHR: cl_context_properties = 0x200B;
 pub const CL_CGL_SHAREGROUP_KHR: cl_context_properties = 0x200C;
 
-// typedef CL_API_ENTRY cl_int (CL_API_CALL *clGetGLContextInfoKHR_fn)(
-//     const cl_context_properties * properties,
-//     cl_gl_context_info            param_name,
-//     size_t                        param_value_size,
-//     void *                        param_value,
-//     size_t *                      param_value_size_ret);
-pub type clGetGLContextInfoKHR_fn = *mut extern "system" fn(
+pub type clGetGLContextInfoKHR_fn = extern "system" fn(
     properties: *const cl_context_properties,
     param_name: cl_gl_context_info,
     param_value_size: size_t,

--- a/cl-sys/src/cl_h.rs
+++ b/cl-sys/src/cl_h.rs
@@ -749,8 +749,8 @@ extern "system" {
     #[cfg(feature = "opencl_version_2_1")]
     pub fn clGetDeviceAndHostTimer(
         device: cl_device_id,
-        device_timestamp: cl_ulong,
-        host_timestamp: cl_ulong,
+        device_timestamp: *mut cl_ulong,
+        host_timestamp: *mut cl_ulong,
     ) -> cl_int;
 
     // extern CL_API_ENTRY cl_int CL_API_CALL
@@ -758,7 +758,7 @@ extern "system" {
     //                cl_ulong *   /* host_timestamp */)  CL_API_SUFFIX__VERSION_2_1;
     //############################### NEW 2.1 #################################
     #[cfg(feature = "opencl_version_2_1")]
-    pub fn clGetHostTimer(device: cl_device_id, host_timestamp: cl_ulong) -> cl_int;
+    pub fn clGetHostTimer(device: cl_device_id, host_timestamp: *mut cl_ulong) -> cl_int;
 
     // Context APIs:
     pub fn clCreateContext(
@@ -1034,7 +1034,7 @@ extern "system" {
         context: cl_context,
         num_devices: cl_uint,
         device_list: *const cl_device_id,
-        kernel_names: *mut char,
+        kernel_names: *const char,
         errcode_ret: *mut cl_int,
     ) -> cl_program;
 

--- a/cl-sys/src/lib.rs
+++ b/cl-sys/src/lib.rs
@@ -68,7 +68,12 @@ pub use self::cl_dx9_media_sharing_h::{
     CL_CONTEXT_ADAPTER_D3D9EX_KHR, CL_CONTEXT_ADAPTER_D3D9_KHR, CL_CONTEXT_ADAPTER_DXVA_KHR,
 };
 
-pub use self::cl_d3d11_h::CL_CONTEXT_D3D11_DEVICE_KHR;
+pub use self::cl_d3d11_h::{
+    clCreateFromD3D11Buffer_fn, clCreateFromD3D11Texture2D_fn, clCreateFromD3D11Texture3D_fn,
+    clEnqueueAcquireD3D11Objects_fn, clEnqueueReleaseD3D11Objects_fn, clGetDeviceIDsFromD3D11_fn,
+    cl_d3d11_device_set, cl_d3d11_device_source, cl_id3d11_buffer, cl_id3d11_texture2d,
+    cl_id3d11_texture3d, CL_CONTEXT_D3D11_DEVICE_KHR,
+};
 
 // Types:
 pub use self::cl_h::{

--- a/ocl-core/src/extension_functions.rs
+++ b/ocl-core/src/extension_functions.rs
@@ -1,0 +1,122 @@
+#![allow(non_snake_case)]
+
+use crate::{
+    get_extension_function_address_for_platform, get_platform_info, Error, PlatformId,
+    PlatformInfo, PlatformInfoResult, Result,
+};
+use cl_sys::*;
+use std::ffi::c_void;
+use std::mem::transmute;
+
+#[derive(Default, Clone)]
+pub struct ExtensionFunctions {
+    // OpenGL
+    pub clGetGLContextInfoKHR: Option<clGetGLContextInfoKHR_fn>,
+
+    // D3D11
+    pub clGetDeviceIDsFromD3D11: Option<clGetDeviceIDsFromD3D11_fn>,
+    pub clCreateFromD3D11Buffer: Option<clCreateFromD3D11Buffer_fn>,
+    pub clCreateFromD3D11Texture2D: Option<clCreateFromD3D11Texture2D_fn>,
+    pub clCreateFromD3D11Texture3D: Option<clCreateFromD3D11Texture3D_fn>,
+    pub clEnqueueAcquireD3D11Objects: Option<clEnqueueAcquireD3D11Objects_fn>,
+    pub clEnqueueReleaseD3D11Objects: Option<clEnqueueReleaseD3D11Objects_fn>,
+}
+
+impl ExtensionFunctions {
+    pub fn resolve_all(platform: PlatformId) -> Result<Self> {
+        let extensions = match get_platform_info(platform, PlatformInfo::Extensions) {
+            Ok(PlatformInfoResult::Extensions(s)) => s,
+            Ok(_) => {
+                return Err(Error::EmptyInfoResult(
+                    crate::EmptyInfoResultError::Platform,
+                ));
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
+
+        let supports_khr_d3d11 = extensions.contains("cl_khr_d3d11_sharing");
+        let supports_nv_d3d11 = extensions.contains("cl_nv_d3d11_sharing");
+
+        let mut functions = Self::default();
+        functions.clGetGLContextInfoKHR =
+            get_pointer(&platform, "clGetGLContextInfoKHR", "")?.map(|p| unsafe { transmute(p) });
+
+        if supports_nv_d3d11 || supports_khr_d3d11 {
+            let suffix = if supports_nv_d3d11 { "NV" } else { "KHR" };
+            functions.clGetDeviceIDsFromD3D11 =
+                get_pointer(&platform, "clGetDeviceIDsFromD3D11", suffix)?
+                    .map(|p| unsafe { transmute(p) });
+            functions.clCreateFromD3D11Buffer =
+                get_pointer(&platform, "clCreateFromD3D11Buffer", suffix)?
+                    .map(|p| unsafe { transmute(p) });
+            functions.clCreateFromD3D11Texture2D =
+                get_pointer(&platform, "clCreateFromD3D11Texture2D", suffix)?
+                    .map(|p| unsafe { transmute(p) });
+            functions.clCreateFromD3D11Texture3D =
+                get_pointer(&platform, "clCreateFromD3D11Texture3D", suffix)?
+                    .map(|p| unsafe { transmute(p) });
+            functions.clEnqueueAcquireD3D11Objects =
+                get_pointer(&platform, "clEnqueueAcquireD3D11Objects", suffix)?
+                    .map(|p| unsafe { transmute(p) });
+            functions.clEnqueueReleaseD3D11Objects =
+                get_pointer(&platform, "clEnqueueReleaseD3D11Objects", suffix)?
+                    .map(|p| unsafe { transmute(p) });
+        }
+        Ok(functions)
+    }
+}
+
+fn get_pointer(
+    platform: &PlatformId,
+    func_name: &str,
+    suffix: &str,
+) -> Result<Option<*mut c_void>> {
+    unsafe {
+        match get_extension_function_address_for_platform(
+            platform,
+            &format!("{}{}", func_name, suffix),
+            None,
+        ) {
+            Ok(pointer) => Ok(Some(pointer)),
+            Err(Error::ApiWrapper(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl std::fmt::Debug for ExtensionFunctions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExtensionFunctions")
+            .field(
+                "clGetGLContextInfoKHR",
+                &self.clGetGLContextInfoKHR.map(|x| x as *mut c_void),
+            )
+            .field(
+                "clGetDeviceIDsFromD3D11",
+                &self.clGetDeviceIDsFromD3D11.map(|x| x as *mut c_void),
+            )
+            .field(
+                "clCreateFromD3D11Buffer",
+                &self.clCreateFromD3D11Buffer.map(|x| x as *mut c_void),
+            )
+            .field(
+                "clCreateFromD3D11Texture2D",
+                &self.clCreateFromD3D11Texture2D.map(|x| x as *mut c_void),
+            )
+            .field(
+                "clCreateFromD3D11Texture3D",
+                &self.clCreateFromD3D11Texture3D.map(|x| x as *mut c_void),
+            )
+            .field(
+                "clEnqueueAcquireD3D11Objects",
+                &self.clEnqueueAcquireD3D11Objects.map(|x| x as *mut c_void),
+            )
+            .field(
+                "clEnqueueReleaseD3D11Objects",
+                &self.clEnqueueReleaseD3D11Objects.map(|x| x as *mut c_void),
+            )
+            .finish()
+    }
+}

--- a/ocl-core/src/lib.rs
+++ b/ocl-core/src/lib.rs
@@ -112,10 +112,12 @@ extern crate num_traits;
 #[cfg(feature = "ocl-core-vector")]
 extern crate ocl_core_vector as vector;
 
-pub mod error;
+mod extension_functions;
 mod functions;
 #[cfg(test)]
 mod tests;
+pub use extension_functions::ExtensionFunctions;
+pub mod error;
 pub mod types;
 pub mod util;
 
@@ -170,6 +172,11 @@ pub use self::functions::{
     create_from_gl_buffer, create_from_gl_renderbuffer, create_from_gl_texture,
     create_from_gl_texture_2d, create_from_gl_texture_3d, enqueue_acquire_gl_objects,
     enqueue_fill_buffer, enqueue_release_gl_objects, get_gl_context_info_khr,
+};
+
+pub use self::functions::{
+    create_from_d3d11_buffer, create_from_d3d11_texture2d, create_from_d3d11_texture3d,
+    enqueue_acquire_d3d11_objects, enqueue_release_d3d11_objects,
 };
 
 pub use crate::traits::{OclNum, OclPrm, OclScl};

--- a/ocl-core/src/types/enums.rs
+++ b/ocl-core/src/types/enums.rs
@@ -706,8 +706,7 @@ impl DeviceInfoResult {
             DeviceInfo::ImageBaseAddressAlignment => {
                 let r = unsafe { util::bytes_into::<u32>(result)? };
                 DeviceInfoResult::ImageBaseAddressAlignment(r)
-            }
-            // _ => DeviceInfoResult::TemporaryPlaceholderVariant(result),
+            } // _ => DeviceInfoResult::TemporaryPlaceholderVariant(result),
         };
 
         Ok(ir)

--- a/ocl-core/src/types/structs.rs
+++ b/ocl-core/src/types/structs.rs
@@ -336,7 +336,7 @@ pub enum ContextPropertyValue {
     AdapterD3d9Khr(isize),
     AdapterD3d9exKhr(isize),
     AdapterDxvaKhr(isize),
-    D3d11DeviceKhr(isize),
+    D3d11DeviceKhr(*mut c_void),
 }
 
 unsafe impl Send for ContextPropertyValue {}
@@ -526,6 +526,12 @@ impl ContextProperties {
                 );
                 self.contains_gl_context_or_sharegroup = true;
             }
+            ContextPropertyValue::D3d11DeviceKhr(val) => {
+                self.props.insert(
+                    ContextProperty::D3d11DeviceKhr,
+                    ContextPropertyValue::D3d11DeviceKhr(val),
+                );
+            }
             _ => panic!("'{:?}' is not yet a supported variant.", prop),
         }
     }
@@ -591,6 +597,10 @@ impl ContextProperties {
                     props_raw.push(sync as isize);
                 }
                 ContextPropertyValue::EglDisplayKhr(sync) => {
+                    props_raw.push(*key as isize);
+                    props_raw.push(sync as isize);
+                }
+                ContextPropertyValue::D3d11DeviceKhr(sync) => {
                     props_raw.push(*key as isize);
                     props_raw.push(sync as isize);
                 }
@@ -746,7 +756,7 @@ impl ContextProperties {
                 ContextProperty::D3d11DeviceKhr => {
                     context_props.props.insert(
                         ContextProperty::D3d11DeviceKhr,
-                        ContextPropertyValue::D3d11DeviceKhr(val_raw),
+                        ContextPropertyValue::D3d11DeviceKhr(val_raw as *mut c_void),
                     );
                 }
             }

--- a/ocl/src/standard/buffer.rs
+++ b/ocl/src/standard/buffer.rs
@@ -17,6 +17,8 @@ use std::ops::{Deref, DerefMut, Range};
 #[cfg(not(feature = "opencl_vendor_mesa"))]
 use crate::ffi::cl_GLuint;
 
+use core::ffi::cl_id3d11_buffer;
+
 fn check_len(mem_len: usize, data_len: usize, offset: usize) -> OclResult<()> {
     if offset >= mem_len {
         Err(format!(
@@ -122,6 +124,8 @@ where
     },
     GLAcquire,
     GLRelease,
+    D3D11Acquire,
+    D3D11Release,
 }
 
 impl<'c, T> BufferCmdKind<'c, T> {
@@ -189,6 +193,7 @@ where
     ewait: Option<ClWaitListPtrEnum<'c>>,
     enew: Option<ClNullEventPtrEnum<'c>>,
     mem_len: usize,
+    ext_fns: Option<&'c core::ExtensionFunctions>,
 }
 
 /// [UNSTABLE]: All methods still in a state of flux.
@@ -203,6 +208,7 @@ where
         buffer: &'c Buffer<T>,
         queue: Option<&'c Queue>,
         /*obj_core: &'c MemCore,*/ mem_len: usize,
+        ext_fns: Option<&'c core::ExtensionFunctions>,
     ) -> BufferCmd<'c, T> {
         BufferCmd {
             buffer,
@@ -213,6 +219,7 @@ where
             ewait: None,
             enew: None,
             mem_len,
+            ext_fns,
         }
     }
 
@@ -424,6 +431,42 @@ where
         self
     }
 
+    /// Specifies that this command will acquire a D3D11 buffer.
+    ///
+    /// If `.block(..)` has been set it will be ignored.
+    ///
+    /// ## Panics
+    ///
+    /// The command operation kind must not have already been specified
+    ///
+    pub fn d3d11_acquire(mut self) -> BufferCmd<'c, T> {
+        assert!(
+            self.kind.is_unspec(),
+            "ocl::BufferCmd::d3d11_acquire(): Operation kind \
+            already set for this command."
+        );
+        self.kind = BufferCmdKind::D3D11Acquire;
+        self
+    }
+
+    /// Specifies that this command will release a D3D11 buffer.
+    ///
+    /// If `.block(..)` has been set it will be ignored.
+    ///
+    /// ## Panics
+    ///
+    /// The command operation kind must not have already been specified
+    ///
+    pub fn d3d11_release(mut self) -> BufferCmd<'c, T> {
+        assert!(
+            self.kind.is_unspec(),
+            "ocl::BufferCmd::d3d11_release(): Operation kind \
+            already set for this command."
+        );
+        self.kind = BufferCmdKind::D3D11Release;
+        self
+    }
+
     /// Specifies that this command will be a fill operation.
     ///
     /// If `.block(..)` has been set it will be ignored.
@@ -627,110 +670,100 @@ where
         };
 
         match self.kind {
-            BufferCmdKind::Copy {
-                dst_buffer,
-                dst_offset,
-                len,
-            } => match self.shape {
-                BufferCmdDataShape::Lin { offset } => {
-                    let len = len.unwrap_or(self.mem_len);
-                    check_len(self.mem_len, len, offset)?;
-                    let dst_offset = dst_offset.unwrap_or(0);
+            BufferCmdKind::Copy { dst_buffer, dst_offset, len } => {
+                match self.shape {
+                    BufferCmdDataShape::Lin { offset } => {
+                        let len = len.unwrap_or(self.mem_len);
+                        check_len(self.mem_len, len, offset)?;
+                        let dst_offset = dst_offset.unwrap_or(0);
 
-                    core::enqueue_copy_buffer::<T, _, _, _>(
-                        queue,
-                        &self.buffer.obj_core,
-                        dst_buffer,
-                        offset,
-                        dst_offset,
-                        len,
-                        self.ewait,
-                        self.enew,
-                    )
-                    .map_err(OclError::from)
-                }
-                BufferCmdDataShape::Rect {
-                    src_origin,
-                    dst_origin,
-                    region,
-                    src_row_pitch_bytes,
-                    src_slc_pitch_bytes,
-                    dst_row_pitch_bytes,
-                    dst_slc_pitch_bytes,
-                } => {
-                    if dst_offset.is_some() || len.is_some() {
-                        return Err(
+                        core::enqueue_copy_buffer::<T, _, _, _>(queue,
+                            &self.buffer.obj_core, dst_buffer, offset, dst_offset, len,
+                            self.ewait, self.enew).map_err(OclError::from)
+                    },
+                    BufferCmdDataShape::Rect { src_origin, dst_origin, region,
+                        src_row_pitch_bytes, src_slc_pitch_bytes, dst_row_pitch_bytes,
+                        dst_slc_pitch_bytes } =>
+                    {
+                        if dst_offset.is_some() || len.is_some() { return Err(
                             "ocl::BufferCmd::enq(): For 'rect' shaped copies, destination \
                             offset and length must be 'None'. Ex.: \
-                            'cmd().copy(&{{buf_name}}, None, None)..'."
-                                .into(),
-                        );
+                            'cmd().copy(&{{buf_name}}, None, None)..'.".into());
+                        }
+
+                        core::enqueue_copy_buffer_rect::<T, _, _, _>(queue, &self.buffer.obj_core,
+                            dst_buffer, src_origin, dst_origin, region, src_row_pitch_bytes,
+                            src_slc_pitch_bytes, dst_row_pitch_bytes, dst_slc_pitch_bytes,
+                            self.ewait, self.enew).map_err(OclError::from)
+                    },
+                }
+            },
+            BufferCmdKind::CopyToImage { image, dst_origin, region } => {
+                match self.shape {
+                    BufferCmdDataShape::Lin { offset } => {
+                        core::enqueue_copy_buffer_to_image::<T, _, _, _>(queue, &self.buffer.obj_core, image, offset,
+                            dst_origin, region, self.ewait, self.enew).map_err(OclError::from)
+                    },
+                    BufferCmdDataShape::Rect { .. } => {
+                        Err("ocl::BufferCmd::enq(): CopyToImage not implemented for rect buffers".into())
                     }
-
-                    core::enqueue_copy_buffer_rect::<T, _, _, _>(
-                        queue,
-                        &self.buffer.obj_core,
-                        dst_buffer,
-                        src_origin,
-                        dst_origin,
-                        region,
-                        src_row_pitch_bytes,
-                        src_slc_pitch_bytes,
-                        dst_row_pitch_bytes,
-                        dst_slc_pitch_bytes,
-                        self.ewait,
-                        self.enew,
-                    )
-                    .map_err(OclError::from)
                 }
             },
 
-            #[cfg(not(feature = "opencl_vendor_mesa"))]
-            BufferCmdKind::Fill { pattern, len } => match self.shape {
-                BufferCmdDataShape::Lin { offset } => {
-                    let len = match len {
-                        Some(l) => l,
-                        None => self.mem_len,
-                    };
+            #[cfg(not(feature="opencl_vendor_mesa"))]
+            BufferCmdKind::Fill { pattern, len } => {
+                match self.shape {
+                    BufferCmdDataShape::Lin { offset } => {
+                        let len = match len {
+                            Some(l) => l,
+                            None => self.mem_len,
+                        };
 
-                    check_len(self.mem_len, len, offset)?;
+                        check_len(self.mem_len, len, offset)?;
 
-                    core::enqueue_fill_buffer(
-                        queue,
-                        &self.buffer.obj_core,
-                        pattern,
-                        offset,
-                        len,
-                        self.ewait,
-                        self.enew,
-                        Some(&queue.device_version()),
-                    )
-                    .map_err(OclError::from)
+                        core::enqueue_fill_buffer(queue, &self.buffer.obj_core, pattern,
+                            offset, len, self.ewait, self.enew, Some(&queue.device_version()))
+                            .map_err(OclError::from)
+                    },
+                    BufferCmdDataShape::Rect { .. } => Err(
+                        "ocl::BufferCmd::enq(): Rectangular fill is not a valid operation. \
+                        Please use the default shape, linear.".into())
                 }
-                BufferCmdDataShape::Rect { .. } => Err(
-                    "ocl::BufferCmd::enq(): Rectangular fill is not a valid operation. \
-                        Please use the default shape, linear."
-                        .into(),
-                ),
             },
-            #[cfg(not(feature = "opencl_vendor_mesa"))]
+            #[cfg(not(feature="opencl_vendor_mesa"))]
             BufferCmdKind::GLAcquire => {
                 let buf_slc = unsafe { std::slice::from_raw_parts(&self.buffer.obj_core, 1) };
-                core::enqueue_acquire_gl_objects(queue, buf_slc, self.ewait, self.enew)
-                    .map_err(OclError::from)
-            }
+                core::enqueue_acquire_gl_objects(queue, buf_slc, self.ewait, self.enew).map_err(OclError::from)
+            },
 
-            #[cfg(not(feature = "opencl_vendor_mesa"))]
+            #[cfg(not(feature="opencl_vendor_mesa"))]
             BufferCmdKind::GLRelease => {
                 let buf_slc = unsafe { std::slice::from_raw_parts(&self.buffer.obj_core, 1) };
-                core::enqueue_release_gl_objects(queue, buf_slc, self.ewait, self.enew)
-                    .map_err(OclError::from)
-            }
+                core::enqueue_release_gl_objects(queue, buf_slc, self.ewait, self.enew).map_err(OclError::from)
+            },
+
+            BufferCmdKind::D3D11Acquire => {
+                match self.ext_fns {
+                    Some(fns) => {
+                        let buf_slc = unsafe { std::slice::from_raw_parts(&self.buffer.obj_core, 1) };
+                        core::enqueue_acquire_d3d11_objects(queue, buf_slc, self.ewait, self.enew, fns).map_err(OclError::from)
+                    }
+                    None => Err("ocl::BufferCmd::enq(): The function pointer to clEnqueueAcquireD3D11Objects was not resolved.".into())
+                }
+            },
+            BufferCmdKind::D3D11Release => {
+                match self.ext_fns {
+                    Some(fns) => {
+                        let buf_slc = unsafe { std::slice::from_raw_parts(&self.buffer.obj_core, 1) };
+                        core::enqueue_release_d3d11_objects(queue, buf_slc, self.ewait, self.enew, fns).map_err(OclError::from)
+                    }
+                    None => Err("ocl::BufferCmd::enq(): The function pointer to clEnqueueReleaseD3D11Objects was not resolved.".into())
+                }
+            },
 
             BufferCmdKind::Unspecified => Err("ocl::BufferCmd::enq(): \
                 No operation specified. Use '.read(...)', 'write(...)', etc. before calling \
-                '.enq()'."
-                .into()),
+                '.enq()'.".into()),
             BufferCmdKind::Map { .. } => unreachable!(),
             _ => unimplemented!(),
         }
@@ -2065,6 +2098,7 @@ pub struct Buffer<T: OclPrm> {
     queue: Option<Queue>,
     len: usize,
     offset: Option<usize>,
+    extension_functions: Option<core::ExtensionFunctions>,
     _data: PhantomData<T>,
 }
 
@@ -2129,6 +2163,7 @@ impl<T: OclPrm> Buffer<T> {
             queue: que_ctx.into(),
             len,
             offset: None,
+            extension_functions: None,
             _data: PhantomData,
         };
 
@@ -2140,6 +2175,9 @@ impl<T: OclPrm> Buffer<T> {
     /// [UNTESTED]
     ///
     /// ### Errors
+    ///
+    /// Remember to specify the GL context when creating the CL context,
+    /// using `.properties(ocl_interop::get_properties_list())`
     ///
     /// Don't forget to `.cmd().gl_acquire().enq()` before using it and
     /// `.cmd().gl_release().enq()` after.
@@ -2176,6 +2214,69 @@ impl<T: OclPrm> Buffer<T> {
             queue: que_ctx.into(),
             len,
             offset: None,
+            extension_functions: None,
+            _data: PhantomData,
+        };
+
+        Ok(buf)
+    }
+
+    /// Creates a buffer linked to a previously created D3D11 buffer object.
+    ///
+    /// [UNTESTED]
+    ///
+    /// ### Errors
+    ///
+    /// Remember to specify the D3D11 device when creating the CL context,
+    /// using `.properties()` and `.set_property_value(ContextPropertyValue::D3d11DeviceKhr(<pointer to ID3D11Device>))`
+    ///
+    /// Don't forget to `.cmd().d3d11_acquire().enq()` before using it and
+    /// `.cmd().d3d11_release().enq()` after.
+    ///
+    /// See the [`BufferCmd` docs](builders/struct.BufferCmd.html)
+    /// for more info.
+    ///
+    pub fn from_d3d11_buffer<'o, Q>(
+        que_ctx: Q,
+        flags_opt: Option<MemFlags>,
+        object: cl_id3d11_buffer,
+    ) -> OclResult<Buffer<T>>
+    where
+        Q: Into<QueCtx<'o>>,
+    {
+        let flags = flags_opt.unwrap_or(core::MEM_READ_WRITE);
+        let que_ctx = que_ctx.into();
+        let context = que_ctx.context_cloned();
+
+        let extension_fns = match context.platform()? {
+            Some(platform) => core::ExtensionFunctions::resolve_all(*platform)?,
+            _ => {
+                return Err(
+                    "ocl::Image::from_d3d11_buffer(): Platform must be set in context.".into(),
+                )
+            }
+        };
+
+        let obj_core = match que_ctx {
+            QueCtx::Queue(ref q) => unsafe {
+                core::create_from_d3d11_buffer(&q.context(), object, flags, &extension_fns)?
+            },
+            QueCtx::Context(c) => unsafe {
+                core::create_from_d3d11_buffer(c, object, flags, &extension_fns)?
+            },
+        };
+
+        let len = match core::get_mem_object_info(&obj_core, MemInfo::Size)? {
+            MemInfoResult::Size(len_bytes) => len_bytes / ::std::mem::size_of::<T>(),
+            _ => unreachable!(),
+        };
+
+        let buf = Buffer {
+            obj_core,
+            queue: que_ctx.into(),
+            len,
+            offset: None,
+            extension_functions: Some(extension_fns),
             _data: PhantomData,
         };
 
@@ -2196,6 +2297,7 @@ impl<T: OclPrm> Buffer<T> {
             self,
             self.queue.as_ref(),
             /*&self.obj_core,*/ self.len(),
+            self.extension_functions.as_ref(),
         )
     }
 
@@ -2506,6 +2608,7 @@ impl<T: OclPrm> Buffer<T> {
             // Share mapped status with super-buffer:
             // is_mapped: self.is_mapped.clone(),
             offset: Some(offset),
+            extension_functions: self.extension_functions.clone(),
             _data: PhantomData,
         })
     }


### PR DESCRIPTION
1. Added functions:
    - `Image::from_d3d11_texture2d`
    - `Image::from_d3d11_texture3d`
    - `Image::d3d11_acquire`
    - `Image::d3d11_release`
    - `Buffer::from_d3d11_buffer`
    - `Buffer::d3d11_acquire`
    - `Buffer::d3d11_release`
2. Supports both `cl_khr_d3d11_sharing` and `cl_nv_d3d11_sharing` extension
3. Fixed `get_gl_context_info_khr`
    - I noticed the debugging note, I had the same crashes with D3D11 extension functions, so I figured out the cause, fixed the method call and verified this function now works so I removed the [INOPERATIVE] comment. This closes #87
4. Implemented `ImageCmd::CopyToBuffer` and `BufferCmd::CopyToImage`
5. Tested OpenGL and DirectX interop on Windows, as well as OpenGL interop on macOS, everything worked for me

Also as a drive by, I included changes from #197 (which closes #196) as they were clear typos in the function signature

Also while going through issues in the repo, I noticed #200, #140, can be already closed.

BTW, great job on this crate really, it makes OpenCL usage so easy and the code is very well structured and covers a lot of APIs and cases, I really appreciate your work here