### PR TITLE
Fix incomplete links in documentation

### DIFF
--- a/ocl/src/standard/buffer.rs
+++ b/ocl/src/standard/buffer.rs
@@ -2340,7 +2340,7 @@ impl<T: OclPrm> Buffer<T> {
     ///
     /// Call `.enq()` to enqueue the command.
     ///
-    /// See the [command builder documentation](builders/struct.BufferCmd)
+    /// See the [command builder documentation](builders/struct.BufferCmd.html)
     /// for more details.
     ///
     ///
@@ -2358,7 +2358,7 @@ impl<T: OclPrm> Buffer<T> {
     ///
     /// Call `.enq()` to enqueue the command.
     ///
-    /// See the [command builder documentation](builders/struct.BufferCmd#method.read)
+    /// See the [command builder documentation](builders/struct.BufferCmd.html#method.read)
     /// for more details.
     ///
     #[inline]
@@ -2374,7 +2374,7 @@ impl<T: OclPrm> Buffer<T> {
     ///
     /// Call `.enq()` to enqueue the command.
     ///
-    /// See the [command builder documentation](builders/struct.BufferCmd#method.write)
+    /// See the [command builder documentation](builders/struct.BufferCmd.html#method.write)
     /// for more details.
     ///
     #[inline]
@@ -2398,7 +2398,7 @@ impl<T: OclPrm> Buffer<T> {
     /// ### More Information
     ///
     /// See the [command builder
-    /// documentation](builders/struct.BufferCmd#method.map) or
+    /// documentation](builders/struct.BufferCmd.html#method.map) or
     /// [official SDK][map_buffer] for more details.
     ///
     /// [map_buffer]: https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clEnqueueMapBuffer.html
@@ -2414,7 +2414,7 @@ impl<T: OclPrm> Buffer<T> {
     ///
     /// Call `.enq()` to enqueue the command.
     ///
-    /// See the [command builder documentation](builders/struct.BufferCmd#method.copy)
+    /// See the [command builder documentation](builders/struct.BufferCmd.html#method.copy)
     /// for more details.
     ///
     #[inline]

--- a/ocl/src/standard/buffer.rs
+++ b/ocl/src/standard/buffer.rs
@@ -2603,7 +2603,7 @@ impl<T: OclPrm> Buffer<T> {
     /// [SDK]: https://www.khronos.org/registry/cl/sdk/1.2/docs/man/xhtml/clCreateSubBuffer.html
     /// [`ocl::flags`]: flags/index.html
     /// [mem_flags]: flags/struct.MemFlags.html
-    /// [`MemFlags::new().read_write()`] flags/struct.MemFlags.html#method.read_write
+    /// [`MemFlags::new().read_write()`]: flags/struct.MemFlags.html#method.read_write
     ///
     pub fn create_sub_buffer<Do, Dl>(
         &self,

--- a/ocl/src/standard/context.rs
+++ b/ocl/src/standard/context.rs
@@ -27,7 +27,7 @@ use std::ops::{Deref, DerefMut};
 pub struct Context(ContextCore);
 
 impl Context {
-    /// Returns a [`ContextBuilder`](/ocl/ocl/struct.ContextBuilder.html).
+    /// Returns a [`ContextBuilder`](/ocl/builders/struct.ContextBuilder.html).
     ///
     /// This is the preferred way to create a Context.
     pub fn builder() -> ContextBuilder {

--- a/ocl/src/standard/image.rs
+++ b/ocl/src/standard/image.rs
@@ -1136,7 +1136,7 @@ impl<T: OclPrm> Image<T> {
     ///
     /// Call `.enq()` to enqueue the command.
     ///
-    /// See the [command builder documentation](struct.ImageCmd)
+    /// See the [command builder documentation](builders/struct.ImageCmd.html)
     /// for more details.
     pub fn cmd(&self) -> ImageCmd<T> {
         ImageCmd::new(
@@ -1151,7 +1151,7 @@ impl<T: OclPrm> Image<T> {
     ///
     /// Call `.enq()` to enqueue the command.
     ///
-    /// See the [command builder documentation](struct.ImageCmd#method.read)
+    /// See the [command builder documentation](builders/struct.ImageCmd.html#method.read)
     /// for more details.
     pub fn read<'c, 'd>(&'c self, data: &'d mut [T]) -> ImageCmd<'c, T>
     where
@@ -1164,7 +1164,7 @@ impl<T: OclPrm> Image<T> {
     ///
     /// Call `.enq()` to enqueue the command.
     ///
-    /// See the [command builder documentation](struct.ImageCmd#method.write)
+    /// See the [command builder documentation](builders/struct.ImageCmd.html#method.write)
     /// for more details.
     pub fn write<'c, 'd>(&'c self, data: &'d [T]) -> ImageCmd<'c, T>
     where
@@ -1182,7 +1182,7 @@ impl<T: OclPrm> Image<T> {
     /// The caller must ensure that only one mapping of a particular memory
     /// region exists at a time.
     ///
-    /// See the [command builder documentation](struct.ImageCmd#method.map)
+    /// See the [command builder documentation](builders/struct.ImageCmd.html#method.map)
     /// for more details.
     ///
     #[inline]
@@ -1195,7 +1195,7 @@ impl<T: OclPrm> Image<T> {
     // ///
     // /// Call `.enq()` to enqueue the command.
     // ///
-    // /// See the [command builder documentation](struct.ImageCmd#method.copy)
+    // /// See the [command builder documentation](builders/struct.ImageCmd.html#method.copy)
     // /// for more details.
     // ///
     // #[inline]

--- a/ocl/src/standard/pro_que.rs
+++ b/ocl/src/standard/pro_que.rs
@@ -100,7 +100,7 @@ impl ProQue {
     ///
     /// See [`KernelBuilder`] documentation for more
     ///
-    /// [`KernelBuilder`]: struct.KernelBuilder.html
+    /// [`KernelBuilder`]: builders/struct.KernelBuilder.html
     pub fn kernel_builder<S>(&self, name: S) -> KernelBuilder
     where
         S: Into<String>,


### PR DESCRIPTION
### Summary

:wave: Hello! This PR updates incomplete links in the documentation to point to the expected page.

### Updated links

Here are the anchors to where these updates begin for each page:

* The `Buffer` page: https://docs.rs/ocl/latest/ocl/struct.Buffer.html#method.cmd
* The `Context` page: https://docs.rs/ocl/latest/ocl/struct.Context.html#method.builder
* The `Image` page: https://docs.rs/ocl/latest/ocl/struct.Image.html#method.cmd
* The `ProQue` page: https://docs.rs/ocl/latest/ocl/struct.ProQue.html#method.kernel_builder

### Notes and questions

I'm slightly unsure of where the links [in this section](https://docs.rs/ocl/latest/ocl/struct.Device.html#method.list) should lead, but am willing to make any suggested updates!

Formatting of the `ocl::core::Status` link is also troublesome and doesn't seem to want to appear inline... Would it make sense to add another line to reference these docs?

https://github.com/cogciprocate/ocl/blob/d0f4b61a872cb7e7fb4c04091a0d34ba774c6ec6/ocl/src/standard/device.rs#L329-L335