### PR TITLE
Fix crate version badge images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ocl
 
 #### [Documentation](https://docs.rs/ocl) | [Change Log](https://github.com/cogciprocate/ocl/blob/master/RELEASES.md)
 
-[![](http://meritbadge.herokuapp.com/ocl)](https://crates.io/crates/ocl) [![](https://docs.rs/ocl/badge.svg)](https://docs.rs/ocl)
+[![](https://img.shields.io/crates/v/ocl.svg)](https://crates.io/crates/ocl) [![](https://docs.rs/ocl/badge.svg)](https://docs.rs/ocl)
 [![Supported platforms](https://img.shields.io/badge/platform-windows%20%7C%20macos%20%7C%20linux%20%7C%20bsd-orange.svg)](https://en.wikipedia.org/wiki/Cross-platform)
 [![Linux Build Status](https://travis-ci.org/cogciprocate/ocl.svg?branch=master)](https://travis-ci.org/cogciprocate/ocl)
 

--- a/cl-sys/README.md
+++ b/cl-sys/README.md
@@ -2,7 +2,7 @@ OpenCL C FFI Bindings.
 
 ### [Documentation](https://docs.rs/cl-sys)
 
-[![](http://meritbadge.herokuapp.com/cl_sys)](https://crates.io/crates/cl_sys)
+[![](https://img.shields.io/crates/v/cl-sys.svg)](https://crates.io/crates/cl_sys)
 [![](https://docs.rs/cl-sys/badge.svg)](https://docs.rs/cl-sys)
 
 For a high level, easier to use, and far less verbose OpenCL interface (that

--- a/ocl-core/README.md
+++ b/ocl-core/README.md
@@ -2,7 +2,7 @@ OpenCL interfaces and types.
 
 #### [Documentation](https://docs.rs/ocl-core)
 
-[![](http://meritbadge.herokuapp.com/ocl_core)](https://crates.io/crates/ocl_core)
+[![](https://img.shields.io/crates/v/ocl-core.svg)](https://crates.io/crates/ocl_core)
 [![](https://docs.rs/ocl-core/badge.svg)](https://docs.rs/ocl-core)
 
 For a higher level, easier to use, and far less verbose OpenCL interface (that

--- a/ocl/README.md
+++ b/ocl/README.md
@@ -1,7 +1,7 @@
 ocl
 ===
 
-[![](http://meritbadge.herokuapp.com/ocl)](https://crates.io/crates/ocl) [![](https://docs.rs/ocl/badge.svg)](https://docs.rs/ocl)
+[![](https://img.shields.io/crates/v/ocl.svg)](https://crates.io/crates/ocl) [![](https://docs.rs/ocl/badge.svg)](https://docs.rs/ocl)
 [![Supported platforms](https://img.shields.io/badge/platform-windows%20%7C%20macos%20%7C%20linux%20%7C%20bsd-orange.svg)](https://en.wikipedia.org/wiki/Cross-platform)
 [![Linux Build Status](https://travis-ci.org/cogciprocate/ocl.svg?branch=master)](https://travis-ci.org/cogciprocate/ocl)
 

--- a/ocl/src/lib.rs
+++ b/ocl/src/lib.rs
@@ -1,4 +1,4 @@
-//! # [![](http://meritbadge.herokuapp.com/ocl)](https://crates.io/crates/ocl) | [GitHub](https://github.com/cogciprocate/ocl)
+//! # [![](https://img.shields.io/crates/v/ocl.svg)](https://crates.io/crates/ocl) | [GitHub](https://github.com/cogciprocate/ocl)
 //!
 //! Rust implementation of the [OpenCL&trade; API].
 //!


### PR DESCRIPTION
### Summary

This PR updates the version badge images in the READMEs and documentation, replacing the missing `http://meritbadge.herokuapp.com` domain with a link to the equivalent badge on `https://img.shields.io/crates/`.

### Notes

I'm happy to change the domain if there's a more preferred one!