### PR TITLE
Fix images example

### DIFF
--- a/ocl/examples/images/src/main.rs
+++ b/ocl/examples/images/src/main.rs
@@ -135,7 +135,7 @@ fn main() {
         .unwrap();
 
     // Not sure why you'd bother creating a sampler on the host but here's how:
-    let sampler = Sampler::new(&context, true, AddressingMode::None, FilterMode::Nearest).unwrap();
+    let sampler = Sampler::new(&context, false, AddressingMode::None, FilterMode::Nearest).unwrap();
 
     let kernel = Kernel::builder()
         .program(&program)


### PR DESCRIPTION
When using `int` coordinates for `read_imagef` normalization of coordinates has to be disabled otherwise the behavior is undefined.