### PR TITLE
Fix `core` conflict with `thiserror`

### DIFF
--- a/ocl/Cargo.toml
+++ b/ocl/Cargo.toml
@@ -58,7 +58,7 @@ default = ["opencl_version_1_1", "opencl_version_1_2"]
 
 [dependencies]
 nodrop = "0.1"
-thiserror = "=1.0.48"
+thiserror = "1.0.50"
 num-traits = "0.2"
 futures = "0.1"
 qutex = "0.2"

--- a/ocl/src/lib.rs
+++ b/ocl/src/lib.rs
@@ -50,7 +50,9 @@
 
 extern crate futures;
 extern crate num_traits;
-pub extern crate ocl_core as core;
+pub extern crate ocl_core;
+
+pub use ocl_core as core;
 
 pub mod r#async;
 pub mod error;

--- a/ocl/src/standard/buffer.rs
+++ b/ocl/src/standard/buffer.rs
@@ -17,7 +17,7 @@ use std::ops::{Deref, DerefMut, Range};
 #[cfg(not(feature = "opencl_vendor_mesa"))]
 use crate::ffi::cl_GLuint;
 
-use core::ffi::cl_id3d11_buffer;
+use crate::core::ffi::cl_id3d11_buffer;
 
 fn check_len(mem_len: usize, data_len: usize, offset: usize) -> OclResult<()> {
     if offset >= mem_len {


### PR DESCRIPTION
This appears to be enough to fix the conflict of `core` in `thiserror 1.0.50`