### PR TITLE
fix cross compilation

### DIFF
--- a/cl-sys/build.rs
+++ b/cl-sys/build.rs
@@ -22,7 +22,7 @@
  */
 
 fn main() {
-    if cfg!(windows) {
+    if std::env::var_os("CARGO_CFG_TARGET_OS") == Some("windows".into()) {
         let known_sdk = [
             // E.g. "c:\Program Files (x86)\Intel\OpenCL SDK\lib\x86\"
             ("INTELOCLSDKROOT", "x64", "x86"),


### PR DESCRIPTION
cfg!(windows) is true in build.rs since build.rs run in host machine. so in case of cross compile for aarch64 target on windows machine for example it wrongly add linker paths whish fail compilation